### PR TITLE
Added customMessage optional param to ReportGUID

### DIFF
--- a/Public.lua
+++ b/Public.lua
@@ -700,10 +700,12 @@ function AddOn_Chomp.CheckReportGUID(prefix, guid)
 	return false, "UNLOGGED"
 end
 
-function AddOn_Chomp.ReportGUID(prefix, guid)
+function AddOn_Chomp.ReportGUID(prefix, guid, customMessage)
 	local prefixData = Internal.Prefixes[prefix]
 	if type(prefix) ~= "string" then
 		error("AddOn_Chomp.ReportTarget(): prefix: expected string, got " .. type(prefix), 2)
+	elseif customMessage ~= nil and type(customMessage) ~= "string" then
+		error("AddOn_Chomp.ReportGUID(): customMessage: expected string, got " .. type(customMessage), 2)
 	elseif type(guid) ~= "string" then
 		error("AddOn_Chomp.ReportTarget(): guid: expected string, got " .. type(guid), 2)
 	elseif not prefixData then
@@ -715,7 +717,7 @@ function AddOn_Chomp.ReportGUID(prefix, guid)
 	end
 	local canReport, reason = AddOn_Chomp.CheckReportGUID(prefix, guid)
 	if canReport then
-		C_ChatInfo.ReportPlayer(PLAYER_REPORT_TYPE_LANGUAGE, ReportLocation, "Objectionable content in logged addon messages.")
+		C_ChatInfo.ReportPlayer(PLAYER_REPORT_TYPE_LANGUAGE, ReportLocation, customMessage or "Objectionable content in logged addon messages.")
 		return true, reason
 	end
 	return false, reason


### PR DESCRIPTION
I would like to offer a GUI to ask the user to give a brief description on why they are reporting a player (is it for harassment, doxxing, adult content). So I added a third optional parameter to `AddOn_Chomp.ReportGUID` to let addons provide a custom message for the report.