### PR TITLE
Iterate over all Battle.net friends

### DIFF
--- a/Public.lua
+++ b/Public.lua
@@ -421,7 +421,7 @@ local function BNGetIDGameAccount(name)
 		return nil
 	end
 	name = AddOn_Chomp.NameMergedRealm(name)
-	for i = 1, select(2, BNGetNumFriends()) do
+	for i = 1, BNGetNumFriends() do
 		for j = 1, BNGetNumFriendGameAccounts(i) do
 			local active, characterName, client, realmName, realmID, faction, race, class, blank, zoneName, level, gameText, broadcastText, broadcastTime, isConnected, bnetIDGameAccount = BNGetFriendGameAccountInfo(i, j)
 			if isConnected and client == BNET_CLIENT_WOW then


### PR DESCRIPTION
Fixes some edge cases with Blizzard's Battle.net API changes back from 8.2, whereby friends at the end of the list after a series of offline & favourited friends wouldn't be considered eligible.