### PR TITLE
Deserialization Error Fixes

### DIFF
--- a/StringManip.lua
+++ b/StringManip.lua
@@ -61,7 +61,7 @@ local Serialize = setmetatable({}, {
 -- This is a meta-type used as a default handler for unknown value types
 -- which always errors; no need to explicitly check types elsewhere.
 Serialize["default"] = function(input)
-    error("invalid type: " .. type(input))
+	error("invalid type: " .. type(input))
 end
 
 Serialize["nil"] = function(input)
@@ -81,40 +81,40 @@ function Serialize.string(input)
 end
 
 function Serialize.table(input)
-    -- These functions are called in loops, so upvalue them eagerly.
-    local floor     = math.floor
-    local strformat = string.format
-    local strfind   = string.find
+	-- These functions are called in loops, so upvalue them eagerly.
+	local floor     = math.floor
+	local strformat = string.format
+	local strfind   = string.find
 	local type      = type
 
-    local output = {}
+	local output = {}
 
-    -- Handle array parts of tables first from `t[1] .. t[n-1]` where `n` is
-    -- the index of the first nil value.
-    local numArray = 0
-    for i, v in ipairs(input) do
-        output[i] = Serialize[type(v)](v)
-        numArray = i
-    end
+	-- Handle array parts of tables first from `t[1] .. t[n]` where `n` is
+	-- the last index before the first nil value.
+	local numArray = 0
+	for i, v in ipairs(input) do
+		output[i] = Serialize[type(v)](v)
+		numArray = i
+	end
 
 	-- `n` is our current offset for additional entries in the table.
-    local n = numArray
+	local n = numArray
 
-    -- Handle the remaining key/value pairs. We want to skip any integral keys
-    -- that are within the `t[1] .. t[numArray]` range.
-    for k, v in pairs(input) do
-        local typeK, typeV = type(k), type(v)
-        if typeK ~= "number" or k > numArray or k < 1 or k ~= floor(k) then
-            n = n + 1
+	-- Handle the remaining key/value pairs. We want to skip any integral keys
+	-- that are within the `t[1] .. t[numArray]` range.
+	for k, v in pairs(input) do
+		local typeK, typeV = type(k), type(v)
+		if typeK ~= "number" or k > numArray or k < 1 or k ~= floor(k) then
+			n = n + 1
 
-            if typeK == "string" and strfind(k, "^[a-zA-Z_][a-zA-Z0-9_]*$") then
-                -- Optimization for identifier-like string keys (no braces!).
-                output[n] = strformat("%s=%s", k, Serialize[typeV](v))
-            else
-                output[n] = strformat("[%s]=%s", Serialize[typeK](k), Serialize[typeV](v))
-            end
-        end
-    end
+			if typeK == "string" and strfind(k, "^[a-zA-Z_][a-zA-Z0-9_]*$") then
+				-- Optimization for identifier-like string keys (no braces!).
+				output[n] = strformat("%s=%s", k, Serialize[typeV](v))
+			else
+				output[n] = strformat("[%s]=%s", Serialize[typeK](k), Serialize[typeV](v))
+			end
+		end
+	end
 
 	return strformat("{%s}", table.concat(output, ","))
 end
@@ -273,7 +273,7 @@ end
 function AddOn_Chomp.EncodeQuotedPrintable(text)
 	if type(text) ~= "string" then
 		error("AddOn_Chomp.EncodeQuotedPrintable(): text: expected string, got " .. type(text), 2)
-    end
+	end
 
 	-- First, the quoted-printable escape character.
 	text = text:gsub("`", CharToQuotedPrintable)

--- a/StringManip.lua
+++ b/StringManip.lua
@@ -22,8 +22,8 @@ local Internal = __chomp_internal
 
 local SAFE_BYTES = {
 	[10] = true, -- newline
-	[61] = true, -- equals
 	[92] = true, -- backslash
+	[96] = true, -- grave
 	[124] = true, -- pipe
 }
 


### PR DESCRIPTION
Fixes at a deserialization error caused by our comms changes for 9.x. Additionally some minor changes to the table serializer to make it do less stuff needlessly.

The theory is that by changing the escape character used for logged comms, the \` character is now escaped to "\`60" on wire. On the receiving end, as it wasn't in the safe characters table, "`60" would be left as is due to taking the "safe decode" path. 

Thankfully a vanishingly small number of comms actually use "`"; sitting in Stormwind on MG netted me ~400 profiles of which no one was using it at all in their profile contents. MSP uses it as part of the protocol but, through dumb luck with how it processes fields with a pattern, it literally skips over the problematic bytes. TRP's case is that our message token scheme uses random characters, hence why this issue seemed so random for us.