### PR TITLE
Allow Battle.net comms to match accounts case-insensitively

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11,7 +11,7 @@ max_string_line_length = false
 max_comment_line_length = false
 
 -- Add exceptions for external libraries.
-std = "lua51+wow+wowstd"
+std = "lua51+wow+wowstd+utf8lib"
 
 globals = {
 	"__chomp_internal",
@@ -96,5 +96,15 @@ stds.wowstd = {
 		},
 
 		"wipe",
+	},
+}
+
+stds.utf8lib = {
+	read_globals = {
+		string = {
+			fields = {
+				"utf8lower",
+			},
+		},
 	},
 }

--- a/Public.lua
+++ b/Public.lua
@@ -423,7 +423,7 @@ local function BNGetIDGameAccount(name)
 				local realm = account.realmName and (account.realmName:gsub("%s*%-*", "")) or nil
 				if realm
 					and (not Internal.SameRealm[realm] or account.factionName ~= UnitFactionGroup("player"))
-					and name == AddOn_Chomp.NameMergedRealm(account.characterName, realm) then
+					and AddOn_Chomp.InsensitiveStringEquals(name, AddOn_Chomp.NameMergedRealm(account.characterName, realm)) then
 					return account.gameAccountID
 				end
 			end

--- a/StringManip.lua
+++ b/StringManip.lua
@@ -54,6 +54,10 @@ function AddOn_Chomp.NameMergedRealm(name, realm)
 	return FULL_PLAYER_NAME:format(name, (realm:gsub("[%s%-]", "")))
 end
 
+function AddOn_Chomp.NameSplitRealm(nameRealm)
+	return string.match(nameRealm, FULL_PLAYER_SPLIT)
+end
+
 local Serialize = setmetatable({}, {
 	__index = function(self) return self["default"] end
 })
@@ -382,4 +386,27 @@ function AddOn_Chomp.SafeSubString(text, first, last, textLen)
 		end
 	end
 	return (text:sub(first, last - offset)), offset
+end
+
+function AddOn_Chomp.InsensitiveStringEquals(a, b)
+	if a == b then
+		return true
+	end
+
+	if type(a) ~= "string" or type(b) ~= "string" then
+		return false
+	end
+
+	-- If the UTF8 library has been loaded (which globally mutates the
+	-- string table - actually helpful here!) we'll prefer that for any case
+	-- insensitive comparisons, since string.lower will use the process
+	-- locale which is likely C, so ASCII only.
+	--
+	-- The UTF8 library is left optional as it's quite large. You can pull it
+	-- in if you want better behaviour in non-English locales.
+	--
+	-- See: <https://www.curseforge.com/wow/addons/utf8>
+
+	local lower = string.utf8lower or string.lower
+	return lower(a) == lower(b)
 end


### PR DESCRIPTION
This improves the internal BNGetIDGameAccount function to compare the name/realms of candidate accounts in a case insensitive manner to what the caller has requested; so if we want to send a message to "someone-kirintor" then we'll correctly find their account in the Battle.net friends list.

A couple of utility string functions are made public for this, one is a case-insensitive string comparison function that will prefer a basic equality test first, followed by using either the UTF8 lib if present, and then falling back to the (locale-dependant, likely ASCII-only) string library.

Additionally a function to split a merged name/realm is added as a utility bonus, since we need it in TRP and rewriting it a million times isn't fun :)