### PR TITLE
Change encoding character

### DIFF
--- a/Chomp.toc
+++ b/Chomp.toc
@@ -5,7 +5,7 @@
 ## X-WoW-Build: 36639
 ## Title: Chomp Message Library
 ## Author: Justin Snelgrove
-## Version: 15
+## Version: 16
 ## Notes: Battle.net and in-game messaging library with smart addon whispers.
 ## X-Category: Library
 ## X-License: ISC

--- a/Internal.lua
+++ b/Internal.lua
@@ -14,7 +14,7 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-local VERSION = 15
+local VERSION = 16
 
 if IsLoggedIn() then
 	error(("Chomp Message Library (embedded: %s) cannot be loaded after login."):format((...)))

--- a/Internal.lua
+++ b/Internal.lua
@@ -129,7 +129,7 @@ local function HandleMessageIn(prefix, text, channel, sender, target, zoneChanne
 		-- Uh, found an unknown bit, or a bit we're explicitly not to parse.
 		if not oneTimeError then
 			oneTimeError = true
-			error("AddOn_Chomp: Recieved an addon message that cannot be parsed, check your addons for updates. (This message will only display once per session, but there may be more unusable addon messages.)")
+			error("AddOn_Chomp: Received an addon message that cannot be parsed, check your addons for updates. (This message will only display once per session, but there may be more unusable addon messages.)")
 		end
 		return
 	end

--- a/Internal.lua
+++ b/Internal.lua
@@ -140,9 +140,9 @@ local function HandleMessageIn(prefix, text, channel, sender, target, zoneChanne
 
 	local hasVersion16 = bit.band(bitField, Internal.BITS.VERSION16) ~= 0
 	if hasVersion16 then
-		prefixData[sender].supportsEncodingV2 = true
+		prefixData[sender].supportsCodecV2 = true
 	else
-		prefixData[sender].supportsEncodingV2 = false
+		prefixData[sender].supportsCodecV2 = false
 	end
 
 	local isBroadcast = bit.band(bitField, Internal.BITS.BROADCAST) == Internal.BITS.BROADCAST
@@ -254,11 +254,11 @@ local function ParseBattleNetMessage(prefix, text, kind, bnetIDGameAccount)
 	return prefix, text, ("%s:BATTLENET"):format(kind), name, AddOn_Chomp.NameMergedRealm(UnitName("player")), 0, 0, "", 0
 end
 
-function Internal:TargetSupportsEncodingV2(prefix, target)
+function Internal:TargetSupportsCodecV2(prefix, target)
 	local prefixData = self.Prefixes[prefix]
 	local targetData = prefixData and prefixData[target] or nil
 
-	return targetData and targetData.supportsEncodingV2 or false
+	return targetData and targetData.supportsCodecV2 or false
 end
 
 function Internal:GetCodecVersionFromBitfield(bitField)

--- a/Public.lua
+++ b/Public.lua
@@ -531,7 +531,7 @@ function AddOn_Chomp.SmartAddonMessage(prefix, data, kind, target, messageOption
 
 	local codecVersion
 
-	if Internal:TargetSupportsEncodingV2(prefix, target) then
+	if Internal:TargetSupportsCodecV2(prefix, target) then
 		codecVersion = 2
 		bitField = bit.bor(bitField, Internal.BITS.CODECV2)
 	else

--- a/StringManip.lua
+++ b/StringManip.lua
@@ -385,7 +385,7 @@ function AddOn_Chomp.EncodeQuotedPrintable(text, codecVersion)
 		if type(codecVersion) ~= "number" then
 			error("AddOn_Chomp.EncodeQuotedPrintable(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
 		elseif not CodecsByVersion[codecVersion] then
-			error("AddOn_Chomp.EncodeQuotedPrintable(): codecVersion: unsupported codec codecVersion " .. type(codecVersion), 2)
+			error("AddOn_Chomp.EncodeQuotedPrintable(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
 		end
 	end
 
@@ -460,7 +460,7 @@ function AddOn_Chomp.DecodeQuotedPrintable(text, codecVersion)
 		if type(codecVersion) ~= "number" then
 			error("AddOn_Chomp.DecodeQuotedPrintable(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
 		elseif not CodecsByVersion[codecVersion] then
-			error("AddOn_Chomp.DecodeQuotedPrintable(): codecVersion: unsupported codec codecVersion " .. type(codecVersion), 2)
+			error("AddOn_Chomp.DecodeQuotedPrintable(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
 		end
 	end
 
@@ -483,7 +483,7 @@ function AddOn_Chomp.SafeSubString(text, first, last, textLen, codecVersion)
 		if type(codecVersion) ~= "number" then
 			error("AddOn_Chomp.SafeSubstring(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
 		elseif not CodecsByVersion[codecVersion] then
-			error("AddOn_Chomp.SafeSubstring(): codecVersion: unsupported codec codecVersion " .. type(codecVersion), 2)
+			error("AddOn_Chomp.SafeSubstring(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
 		end
 	end
 

--- a/StringManip.lua
+++ b/StringManip.lua
@@ -20,11 +20,77 @@ end
 
 local Internal = __chomp_internal
 
-local SAFE_BYTES = {
+-- Version 1, using "`" as the escape sequence character. Deprecated and will be removed eventually.
+local CodecV1 = {}
+
+CodecV1.DECODE_PATTERN = "`(%x%x)"
+CodecV1.ESCAPE_CHAR = "`"
+CodecV1.ESCAPE_BYTE = string.byte(CodecV1.ESCAPE_CHAR)
+CodecV1.SAFE_BYTES = {
+	[10] = true, -- newline
+	[92] = true, -- backslash
+	[96] = true, -- grave
+	[124] = true, -- pipe
+}
+
+function CodecV1.DecodeSafeByte(b)
+	local byteNum = tonumber(b, 16)
+	if CodecV1.SAFE_BYTES[byteNum] then
+		return string.char(byteNum)
+	else
+		return ("`%02X"):format(byteNum)
+	end
+end
+
+function CodecV1.EncodeCharToQuotedPrintable(c)
+	return ("`%02X"):format(c:byte())
+end
+
+function CodecV1.EncodeStringToQuotedPrintable(s)
+	return (s:gsub(".", CodecV1.EncodeCharToQuotedPrintable))
+end
+
+function CodecV1.EncodeTooManyContinuations(s1, s2)
+	return s1 .. (s2:gsub(".", CodecV1.EncodeCharToQuotedPrintable))
+end
+
+-- Version 2, using "~" as the escape sequence character.
+local CodecV2 = {}
+
+CodecV2.DECODE_PATTERN = "~(%x%x)"
+CodecV2.ESCAPE_CHAR = "~"
+CodecV2.ESCAPE_BYTE = string.byte(CodecV2.ESCAPE_CHAR)
+CodecV2.SAFE_BYTES = {
 	[10] = true, -- newline
 	[92] = true, -- backslash
 	[124] = true, -- pipe
 	[126] = true, -- tilde
+}
+
+function CodecV2.DecodeSafeByte(b)
+	local byteNum = tonumber(b, 16)
+	if CodecV2.SAFE_BYTES[byteNum] then
+		return string.char(byteNum)
+	else
+		return ("~%02X"):format(byteNum)
+	end
+end
+
+function CodecV2.EncodeCharToQuotedPrintable(c)
+	return ("~%02X"):format(c:byte())
+end
+
+function CodecV2.EncodeStringToQuotedPrintable(s)
+	return (s:gsub(".", CodecV2.EncodeCharToQuotedPrintable))
+end
+
+function CodecV2.EncodeTooManyContinuations(s1, s2)
+	return s1 .. (s2:gsub(".", CodecV2.EncodeCharToQuotedPrintable))
+end
+
+local CodecsByVersion = {
+	[1] = CodecV1,
+	[2] = CodecV2,
 }
 
 -- Realm part matching is greedy, as realm names will rarely have dashes, but
@@ -254,127 +320,125 @@ function AddOn_Chomp.CheckLoggedContents(text)
 	return true, nil
 end
 
-local function CharToQuotedPrintable(c)
-	return ("~%02X"):format(c:byte())
-end
+function Internal.EncodeQuotedPrintable(text, restrictBinary, codecVersion)
+	local codec = CodecsByVersion[codecVersion]
 
-local function StringToQuotedPrintable(s)
-	return (s:gsub(".", CharToQuotedPrintable))
-end
-
-local function TooManyContinuations(s1, s2)
-	return s1 .. (s2:gsub(".", CharToQuotedPrintable))
-end
-
-function Internal.EncodeQuotedPrintable(text, restrictBinary)
 	-- First, the quoted-printable escape character.
-	text = text:gsub("~", CharToQuotedPrintable)
+	text = text:gsub(codec.ESCAPE_CHAR, codec.EncodeCharToQuotedPrintable)
 
 	if not restrictBinary then
 		-- Just NUL, which never works normally.
-		text = text:gsub("%z", CharToQuotedPrintable)
+		text = text:gsub("%z", codec.EncodeCharToQuotedPrintable)
 
 		-- Bytes not used in UTF-8 ever.
-		text = text:gsub("[\192\193\245-\255]", CharToQuotedPrintable)
+		text = text:gsub("[\192\193\245-\255]", codec.EncodeCharToQuotedPrintable)
 
 		-- Multiple leading bytes.
 		text = text:gsub("[\194-\244]+[\194-\244]", function(s)
-			return (s:gsub(".", CharToQuotedPrintable, #s - 1))
+			return (s:gsub(".", codec.EncodeCharToQuotedPrintable, #s - 1))
 		end)
 
 		--- Unicode 11.0.0, Table 3-7 malformed UTF-8 byte sequences.
-		text = text:gsub("\224[\128-\159][\128-\191]", StringToQuotedPrintable)
-		text = text:gsub("\240[\128-\143][\128-\191][\128-\191]", StringToQuotedPrintable)
-		text = text:gsub("\244[\143-\191][\128-\191][\128-\191]", StringToQuotedPrintable)
+		text = text:gsub("\224[\128-\159][\128-\191]", codec.EncodeStringToQuotedPrintable)
+		text = text:gsub("\240[\128-\143][\128-\191][\128-\191]", codec.EncodeStringToQuotedPrintable)
+		text = text:gsub("\244[\143-\191][\128-\191][\128-\191]", codec.EncodeStringToQuotedPrintable)
 
 		-- UTF-16 reserved codepoints
-		text = text:gsub("\237\158[\154-\191]", StringToQuotedPrintable)
-		text = text:gsub("\237[\159-\191][\128-\191]", StringToQuotedPrintable)
+		text = text:gsub("\237\158[\154-\191]", codec.EncodeStringToQuotedPrintable)
+		text = text:gsub("\237[\159-\191][\128-\191]", codec.EncodeStringToQuotedPrintable)
 
 		-- Unicode invalid codepoints
-		text = text:gsub("\239\191[\190\191]", StringToQuotedPrintable)
+		text = text:gsub("\239\191[\190\191]", codec.EncodeStringToQuotedPrintable)
 
 		-- 2-4-byte leading bytes without enough continuation bytes.
-		text = text:gsub("[\194-\244]%f[^\128-\191\194-\244]", CharToQuotedPrintable)
+		text = text:gsub("[\194-\244]%f[^\128-\191\194-\244]", codec.EncodeCharToQuotedPrintable)
 		-- 3-4-byte leading bytes without enough continuation bytes.
-		text = text:gsub("[\224-\244][\128-\191]%f[^\128-\191]", StringToQuotedPrintable)
+		text = text:gsub("[\224-\244][\128-\191]%f[^\128-\191]", codec.EncodeStringToQuotedPrintable)
 		-- 4-byte leading bytes without enough continuation bytes.
-		text = text:gsub("[\240-\244][\128-\191][\128-\191]%f[^\128-\191]", StringToQuotedPrintable)
+		text = text:gsub("[\240-\244][\128-\191][\128-\191]%f[^\128-\191]", codec.EncodeStringToQuotedPrintable)
 
 		-- Continuation bytes without leading bytes.
-		text = text:gsub("%f[\128-\191\194-\244][\128-\191]+", StringToQuotedPrintable)
+		text = text:gsub("%f[\128-\191\194-\244][\128-\191]+", codec.EncodeStringToQuotedPrintable)
 
 		-- 2-byte character with too many continuation bytes
-		text = text:gsub("([\194-\223][\128-\191])([\128-\191]+)", TooManyContinuations)
+		text = text:gsub("([\194-\223][\128-\191])([\128-\191]+)", codec.EncodeTooManyContinuations)
 		-- 3-byte character with too many continuation bytes
-		text = text:gsub("([\224-\239][\128-\191][\128-\191])([\128-\191]+)", TooManyContinuations)
+		text = text:gsub("([\224-\239][\128-\191][\128-\191])([\128-\191]+)", codec.EncodeTooManyContinuations)
 		-- 4-byte character with too many continuation bytes
-		text = text:gsub("([\240-\244][\128-\191][\128-\191][\128-\191])([\128-\191]+)", TooManyContinuations)
+		text = text:gsub("([\240-\244][\128-\191][\128-\191][\128-\191])([\128-\191]+)", codec.EncodeTooManyContinuations)
 	else
 		-- Binary-restricted messages don't permit UI escape sequences.
-		text = text:gsub("|", CharToQuotedPrintable)
+		text = text:gsub("|", codec.EncodeCharToQuotedPrintable)
 		-- They're also picky about backslashes -- ex. \\n (literal \n) fails.
-		text = text:gsub("\\", CharToQuotedPrintable)
+		text = text:gsub("\\", codec.EncodeCharToQuotedPrintable)
 		-- Newlines are truly necessary but not permitted.
-		text = text:gsub("\010", CharToQuotedPrintable)
+		text = text:gsub("\010", codec.EncodeCharToQuotedPrintable)
 	end
 
 	return text
 end
 
-function AddOn_Chomp.EncodeQuotedPrintable(text)
+function AddOn_Chomp.EncodeQuotedPrintable(text, codecVersion)
 	if type(text) ~= "string" then
 		error("AddOn_Chomp.EncodeQuotedPrintable(): text: expected string, got " .. type(text), 2)
+	elseif codecVersion ~= nil then
+		if type(codecVersion) ~= "number" then
+			error("AddOn_Chomp.EncodeQuotedPrintable(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
+		elseif not CodecsByVersion[codecVersion] then
+			error("AddOn_Chomp.EncodeQuotedPrintable(): codecVersion: unsupported codec codecVersion " .. type(codecVersion), 2)
+		end
 	end
 
+	local codec = CodecsByVersion[codecVersion or 1]
+
 	-- First, the quoted-printable escape character.
-	text = text:gsub("~", CharToQuotedPrintable)
+	text = text:gsub(codec.ESCAPE_CHAR, codec.EncodeCharToQuotedPrintable)
 
 	-- Logged messages don't permit UI escape sequences.
-	text = text:gsub("|", CharToQuotedPrintable)
+	text = text:gsub("|", codec.EncodeCharToQuotedPrintable)
 	-- They're also picky about backslashes -- ex. \\n (literal \n) fails.
-	text = text:gsub("\\", CharToQuotedPrintable)
+	text = text:gsub("\\", codec.EncodeCharToQuotedPrintable)
 	-- Some characters are considered abusive-by-default by Blizzard.
-	text = text:gsub("\229\141[\141\144]", StringToQuotedPrintable)
+	text = text:gsub("\229\141[\141\144]", codec.EncodeStringToQuotedPrintable)
 	-- ASCII control characters. \009 and \127 are allowed for some reason.
-	text = text:gsub("[%z\001-\008\010-\031]", CharToQuotedPrintable)
+	text = text:gsub("[%z\001-\008\010-\031]", codec.EncodeCharToQuotedPrintable)
 
 	-- Bytes not used in UTF-8 ever.
-	text = text:gsub("[\192\193\245-\255]", CharToQuotedPrintable)
+	text = text:gsub("[\192\193\245-\255]", codec.EncodeCharToQuotedPrintable)
 
 	-- Multiple leading bytes.
 	text = text:gsub("[\194-\244]+[\194-\244]", function(s)
-		return (s:gsub(".", CharToQuotedPrintable, #s - 1))
+		return (s:gsub(".", codec.EncodeCharToQuotedPrintable, #s - 1))
 	end)
 
 	--- Unicode 11.0.0, Table 3-7 malformed UTF-8 byte sequences.
-	text = text:gsub("\224[\128-\159][\128-\191]", StringToQuotedPrintable)
-	text = text:gsub("\240[\128-\143][\128-\191][\128-\191]", StringToQuotedPrintable)
-	text = text:gsub("\244[\143-\191][\128-\191][\128-\191]", StringToQuotedPrintable)
+	text = text:gsub("\224[\128-\159][\128-\191]", codec.EncodeStringToQuotedPrintable)
+	text = text:gsub("\240[\128-\143][\128-\191][\128-\191]", codec.EncodeStringToQuotedPrintable)
+	text = text:gsub("\244[\143-\191][\128-\191][\128-\191]", codec.EncodeStringToQuotedPrintable)
 
 	-- UTF-16 reserved codepoints
-	text = text:gsub("\237\158[\154-\191]", StringToQuotedPrintable)
-	text = text:gsub("\237[\159-\191][\128-\191]", StringToQuotedPrintable)
+	text = text:gsub("\237\158[\154-\191]", codec.EncodeStringToQuotedPrintable)
+	text = text:gsub("\237[\159-\191][\128-\191]", codec.EncodeStringToQuotedPrintable)
 
 	-- Unicode invalid codepoints
-	text = text:gsub("\239\191[\190\191]", StringToQuotedPrintable)
+	text = text:gsub("\239\191[\190\191]", codec.EncodeStringToQuotedPrintable)
 
 	-- 2-4-byte leading bytes without enough continuation bytes.
-	text = text:gsub("[\194-\244]%f[^\128-\191\194-\244]", CharToQuotedPrintable)
+	text = text:gsub("[\194-\244]%f[^\128-\191\194-\244]", codec.EncodeCharToQuotedPrintable)
 	-- 3-4-byte leading bytes without enough continuation bytes.
-	text = text:gsub("[\224-\244][\128-\191]%f[^\128-\191]", StringToQuotedPrintable)
+	text = text:gsub("[\224-\244][\128-\191]%f[^\128-\191]", codec.EncodeStringToQuotedPrintable)
 	-- 4-byte leading bytes without enough continuation bytes.
-	text = text:gsub("[\240-\244][\128-\191][\128-\191]%f[^\128-\191]", StringToQuotedPrintable)
+	text = text:gsub("[\240-\244][\128-\191][\128-\191]%f[^\128-\191]", codec.EncodeStringToQuotedPrintable)
 
 	-- Continuation bytes without leading bytes.
-	text = text:gsub("%f[\128-\191\194-\244][\128-\191]+", StringToQuotedPrintable)
+	text = text:gsub("%f[\128-\191\194-\244][\128-\191]+", codec.EncodeStringToQuotedPrintable)
 
 	-- 2-byte character with too many continuation bytes
-	text = text:gsub("([\194-\223][\128-\191])([\128-\191]+)", TooManyContinuations)
+	text = text:gsub("([\194-\223][\128-\191])([\128-\191]+)", codec.EncodeTooManyContinuations)
 	-- 3-byte character with too many continuation bytes
-	text = text:gsub("([\224-\239][\128-\191][\128-\191])([\128-\191]+)", TooManyContinuations)
+	text = text:gsub("([\224-\239][\128-\191][\128-\191])([\128-\191]+)", codec.EncodeTooManyContinuations)
 	-- 4-byte character with too many continuation bytes
-	text = text:gsub("([\240-\244][\128-\191][\128-\191][\128-\191])([\128-\191]+)", TooManyContinuations)
+	text = text:gsub("([\240-\244][\128-\191][\128-\191][\128-\191])([\128-\191]+)", codec.EncodeTooManyContinuations)
 
 	return text
 end
@@ -383,29 +447,30 @@ local function DecodeAnyByte(b)
 	return string.char(tonumber(b, 16))
 end
 
-local function DecodeSafeByte(b)
-	local byteNum = tonumber(b, 16)
-	if SAFE_BYTES[byteNum] then
-		return string.char(byteNum)
-	else
-		return ("~%02X"):format(byteNum)
-	end
-end
-
-function Internal.DecodeQuotedPrintable(text, restrictBinary)
-	local decodedText = text:gsub("~(%x%x)", not restrictBinary and DecodeAnyByte or DecodeSafeByte)
+function Internal.DecodeQuotedPrintable(text, restrictBinary, codecVersion)
+	local codec = CodecsByVersion[codecVersion]
+	local decodedText = text:gsub(codec.DECODE_PATTERN, not restrictBinary and DecodeAnyByte or codec.DecodeSafeByte)
 	return decodedText
 end
 
-function AddOn_Chomp.DecodeQuotedPrintable(text)
+function AddOn_Chomp.DecodeQuotedPrintable(text, codecVersion)
 	if type(text) ~= "string" then
 		error("AddOn_Chomp.DecodeQuotedPrintable(): text: expected string, got " .. type(text), 2)
+	elseif codecVersion ~= nil then
+		if type(codecVersion) ~= "number" then
+			error("AddOn_Chomp.DecodeQuotedPrintable(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
+		elseif not CodecsByVersion[codecVersion] then
+			error("AddOn_Chomp.DecodeQuotedPrintable(): codecVersion: unsupported codec codecVersion " .. type(codecVersion), 2)
+		end
 	end
-	local decodedText = text:gsub("~(%x%x)", DecodeAnyByte)
+
+	local codec = CodecsByVersion[codecVersion or 1]
+
+	local decodedText = text:gsub(codec.DECODE_PATTERN, DecodeAnyByte)
 	return decodedText
 end
 
-function AddOn_Chomp.SafeSubString(text, first, last, textLen)
+function AddOn_Chomp.SafeSubString(text, first, last, textLen, codecVersion)
 	if type(text) ~= "string" then
 		error("AddOn_Chomp.SafeSubString(): text: expected string, got " .. type(text), 2)
 	elseif type(first) ~= "number" then
@@ -414,7 +479,16 @@ function AddOn_Chomp.SafeSubString(text, first, last, textLen)
 		error("AddOn_Chomp.SafeSubString(): last: expected number, got " .. type(last), 2)
 	elseif textLen and type(textLen) ~= "number" then
 		error("AddOn_Chomp.SafeSubString(): textLen: expected number or nil, got " .. type(textLen), 2)
+	elseif codecVersion ~= nil then
+		if type(codecVersion) ~= "number" then
+			error("AddOn_Chomp.SafeSubstring(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
+		elseif not CodecsByVersion[codecVersion] then
+			error("AddOn_Chomp.SafeSubstring(): codecVersion: unsupported codec codecVersion " .. type(codecVersion), 2)
+		end
 	end
+
+	local codec = CodecsByVersion[codecVersion or 1]
+
 	local offset = 0
 	if not textLen then
 		textLen = #text
@@ -424,10 +498,9 @@ function AddOn_Chomp.SafeSubString(text, first, last, textLen)
 	end
 	if textLen > last then
 		local b3, b2, b1 = text:byte(last - 2, last)
-		-- 126 is numeric code for "~"
-		if b1 == 126 or (b1 >= 194 and b1 <= 244) then
+		if b1 == codec.ESCAPE_BYTE or (b1 >= 194 and b1 <= 244) then
 			offset = 1
-		elseif b2 == 126 or (b2 >= 224 and b2 <= 244) then
+		elseif b2 == codec.ESCAPE_BYTE or (b2 >= 224 and b2 <= 244) then
 			offset = 2
 		elseif b3 >= 240 and b3 <= 244 then
 			offset = 3


### PR DESCRIPTION
This changes the encoding character for escaping specific sequences from "\`" to "~".

It was known in 9.0 that this would slightly conflict with MSP, however I'd also believed that issue was fixable there. Unfortunately fixing it would cause more issues than it'd solve, so this changeset aims to use a neutral character that should be uncommon and otherwise largely unused.

Taking advantage of a typo we've managed to figure out a way to have this change work without actually breaking the world or requiring prefix bumps. The previously unused 8th flag on comms was misspelled as `UNUSES8`, which means that old versions of Chomp don't consider this bit to be unused and thus won't raise a message or drop comms if this bit is set upon receipt.

When this change is applied, Chomp v16+ will set this unused bit - now called `VERSION16` - for all comms. Older clients will ignore it thinking it's a known bit and won't process it, but people also running v16+ will have this information cached in a per-sender table to indicate that they're running this new version.

When sending data to a player we check if we've got v16+ support information known for a target based on prior comms. If we do, we'll use the new escape sequence character and set a _separate_ bit called `CODECV2` to indicate that the new encoding scheme should be used. By default we don't set this if the support isn't known, so older clients won't break, and everything upgrades itself smoothly.

In the edge case where a user logs in with Chomp v16+, exchanges comms, and then relogs with an older version, they will receive the warning message from the (unknown) `CODECV2` bit - however in such a case if the user sends a message to another player they'd leave the `VERSION16` bit unset and the cached information would be cleared, so they wouldn't _completely_ break.
