### PR TITLE
Lower burst/sustained rate for non-retail clients

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -90,6 +90,8 @@ stds.wow = {
 		"UnitName",
 		"UnitRealmRelationship",
 		"UNKNOWNOBJECT",
+		"WOW_PROJECT_ID",
+		"WOW_PROJECT_RETAIL",
 	},
 }
 

--- a/Internal.lua
+++ b/Internal.lua
@@ -40,6 +40,8 @@ local Internal = __chomp_internal
 
 -- Safe instantaneous burst bytes and safe susatined bytes per second.
 -- Lower rates on non-Retail clients due to aggressive throttling.
+local BURST, BPS
+
 if WOW_PROJECT_ID == WOW_PROJECT_RETAIL then
 	BURST, BPS = 8192, 2048
 else

--- a/Internal.lua
+++ b/Internal.lua
@@ -39,7 +39,13 @@ local Internal = __chomp_internal
 ]]
 
 -- Safe instantaneous burst bytes and safe susatined bytes per second.
-local BURST, BPS = 8192, 2048
+-- Lower rates on non-Retail clients due to aggressive throttling.
+if WOW_PROJECT_ID == WOW_PROJECT_RETAIL then
+	BURST, BPS = 8192, 2048
+else
+	BURST, BPS = 4000, 800
+end
+
 -- These values were safe on 8.0 beta, but are unsafe on 7.3 live. Normally I'd
 -- love to automatically use them if 8.0 is live, but it's not 100% clear if
 -- this is a 8.0 thing or a test realm thing.


### PR DESCRIPTION
Classic has aggressive comms throttling on group channels. As Chomp replaces CTL in a nasty way (which we should really fix...) we could be causing issues by setting these values higher than CTLs' own, which itself already overshoots the throttle in some cases.

These changes make the rates match CTL for non-retail clients, so while we'll be slower there we won't at least be causing any more issues than CTL potentially can.