### PR TITLE
Use LibStub for versioning

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -24,6 +24,7 @@ read_globals = {
 
 	-- LibStub
 	"LibStub.GetLibrary",
+	"LibStub.NewLibrary",
 
 	-- Global APIs
 	"Ambiguate",

--- a/CTLCompat.lua
+++ b/CTLCompat.lua
@@ -19,11 +19,12 @@
 	mikk, which was released into the public domain.
 ]]
 
-if not __chomp_internal or not __chomp_internal.LOADING then
+local Chomp = LibStub:GetLibrary("Chomp", true)
+local Internal = Chomp and Chomp.Internal or nil
+
+if not Chomp or not Internal or not Internal.LOADING then
 	return
 end
-
-local Internal = __chomp_internal
 
 -- The following code provides a compatibility layer for addons using
 -- ChatThrottleLib. It won't load (and Chomp will feed messages into CTL) if

--- a/CTLCompat.lua
+++ b/CTLCompat.lua
@@ -61,7 +61,7 @@ function ChatThrottleLib:SendAddonMessage(priorityName, prefix, text, kind, targ
 	if kind == "CHANNEL" then
 		target = tonumber(target)
 	end
-	AddOn_Chomp.SendAddonMessage(prefix, text, kind, target, PRIORITY_FROM_CTL[priorityName], queueName or ("%s%s%s"):format(prefix, kind, (tostring(target) or "")), callback, callbackArg)
+	Chomp.SendAddonMessage(prefix, text, kind, target, PRIORITY_FROM_CTL[priorityName], queueName or ("%s%s%s"):format(prefix, kind, (tostring(target) or "")), callback, callbackArg)
 end
 
 function ChatThrottleLib:SendChatMessage(priorityName, prefix, text, kind, language, target, queueName, callback, callbackArg)
@@ -75,7 +75,7 @@ function ChatThrottleLib:SendChatMessage(priorityName, prefix, text, kind, langu
 	if kind == "CHANNEL" then
 		target = tonumber(target)
 	end
-	AddOn_Chomp.SendChatMessage(text, kind, language, target, PRIORITY_FROM_CTL[priorityName], queueName or ("%s%s%s"):format(prefix, (kind or "SAY"), (tostring(target) or "")), callback, callbackArg)
+	Chomp.SendChatMessage(text, kind, language, target, PRIORITY_FROM_CTL[priorityName], queueName or ("%s%s%s"):format(prefix, (kind or "SAY"), (tostring(target) or "")), callback, callbackArg)
 end
 
 function ChatThrottleLib.Hook_SendAddonMessage()

--- a/Chomp.xml
+++ b/Chomp.xml
@@ -9,8 +9,11 @@
 	<Include file="CTLCompat.lua"/>
 
 	<Script>
-		if __chomp_internal and __chomp_internal.LOADING then
-			__chomp_internal.LOADING = nil
+		local Chomp = LibStub:GetLibrary("Chomp", true)
+		local Internal = Chomp and Chomp.Internal or nil
+
+		if Chomp and Internal then
+			Internal.LOADING = nil
 		end
 	</Script>
 </Ui>

--- a/Internal.lua
+++ b/Internal.lua
@@ -563,6 +563,8 @@ function Internal:UpdateBattleNetAccountData()
 
 	if not BNFeaturesEnabledAndConnected() then
 		return  -- Player isn't connected to Battle.net.
+	elseif not IsLoggedIn() then
+		return  -- Player hasn't yet logged in.
 	end
 
 	for _, _, account in EnumerateFriendGameAccounts() do

--- a/Internal.lua
+++ b/Internal.lua
@@ -14,25 +14,23 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-local VERSION = 18
+local VERSION = 19
 
 if IsLoggedIn() then
 	error(("Chomp Message Library (embedded: %s) cannot be loaded after login."):format((...)))
-elseif __chomp_internal and (__chomp_internal.VERSION or 0) >= VERSION then
 	return
 end
 
-if not __chomp_internal then
-	__chomp_internal = CreateFrame("Frame")
+local Chomp = LibStub:NewLibrary("Chomp", VERSION)
+
+if not Chomp then
+	return
 end
 
-if not AddOn_Chomp then
-	AddOn_Chomp = {}
-end
+Chomp.Internal = Chomp.Internal or __chomp_internal or CreateFrame("Frame")
+Chomp.Internal.LOADING = true
 
-__chomp_internal.LOADING = true
-
-local Internal = __chomp_internal
+local Internal = Chomp.Internal
 
 Internal.callbacks = LibStub:GetLibrary("CallbackHandler-1.0"):New(Internal)
 
@@ -689,3 +687,14 @@ Internal:SetScript("OnEvent", function(self, event, ...)
 end)
 
 Internal.VERSION = VERSION
+
+-- v19+: The future is now old man. These need to exist for compatibility, and
+--       to prevent issues where pre-v19 versions would replace newer ones if
+--       __chomp_internal were to just disappear.
+--
+--       Note that we still clear __chomp_internal once PLAYER_LOGIN has
+--       fired, but we don't remove  access to it from the library table
+--       because being able to inspect it at runtime is nice.
+
+_G.__chomp_internal = Internal
+_G.AddOn_Chomp = Chomp

--- a/Internal.lua
+++ b/Internal.lua
@@ -148,7 +148,7 @@ local function HandleMessageIn(prefix, text, channel, sender, target, zoneChanne
 		-- Uh, found an unknown bit, or a bit we're explicitly not to parse.
 		if not oneTimeError then
 			oneTimeError = true
-			error("AddOn_Chomp: Received an addon message that cannot be parsed, check your addons for updates. (This message will only display once per session, but there may be more unusable addon messages.)")
+			error("Chomp: Received an addon message that cannot be parsed, check your addons for updates. (This message will only display once per session, but there may be more unusable addon messages.)")
 		end
 		return
 	end
@@ -173,7 +173,7 @@ local function HandleMessageIn(prefix, text, channel, sender, target, zoneChanne
 		end
 		if msgID == 1 then
 			local broadcastTarget, broadcastText = text:match("^([^\058\127]*)[\058\127](.*)$")
-			local ourName = AddOn_Chomp.NameMergedRealm(UnitFullName("player"))
+			local ourName = Chomp.NameMergedRealm(UnitFullName("player"))
 			if sender == ourName or broadcastTarget ~= "" and broadcastTarget ~= ourName then
 				-- Not for us, quit processing.
 				return
@@ -224,7 +224,7 @@ local function HandleMessageIn(prefix, text, channel, sender, target, zoneChanne
 			if fullMsgOnly then
 				handlerData = table.concat(buffer)
 				if deserialize then
-					local success, original = pcall(AddOn_Chomp.Deserialize, handlerData)
+					local success, original = pcall(Chomp.Deserialize, handlerData)
 					if success then
 						handlerData = original
 					else
@@ -248,16 +248,16 @@ end
 
 local function ParseInGameMessage(prefix, text, kind, sender, target, zoneChannelID, localID, name, instanceID)
 	if kind == "WHISPER" then
-		target = AddOn_Chomp.NameMergedRealm(target)
+		target = Chomp.NameMergedRealm(target)
 	end
-	return prefix, text, kind, AddOn_Chomp.NameMergedRealm(sender), target, zoneChannelID, localID, name, instanceID
+	return prefix, text, kind, Chomp.NameMergedRealm(sender), target, zoneChannelID, localID, name, instanceID
 end
 
 local function ParseInGameMessageLogged(prefix, text, kind, sender, target, zoneChannelID, localID, name, instanceID)
 	if kind == "WHISPER" then
-		target = AddOn_Chomp.NameMergedRealm(target)
+		target = Chomp.NameMergedRealm(target)
 	end
-	return prefix, text, ("%s:LOGGED"):format(kind), AddOn_Chomp.NameMergedRealm(sender), target, zoneChannelID, localID, name, instanceID
+	return prefix, text, ("%s:LOGGED"):format(kind), Chomp.NameMergedRealm(sender), target, zoneChannelID, localID, name, instanceID
 end
 
 local function ParseBattleNetMessage(prefix, text, kind, bnetIDGameAccount)
@@ -267,7 +267,7 @@ local function ParseBattleNetMessage(prefix, text, kind, bnetIDGameAccount)
 		return
 	end
 
-	return prefix, text, ("%s:BATTLENET"):format(kind), name, AddOn_Chomp.NameMergedRealm(UnitName("player")), 0, 0, "", 0
+	return prefix, text, ("%s:BATTLENET"):format(kind), name, Chomp.NameMergedRealm(UnitName("player")), 0, 0, "", 0
 end
 
 function Internal:TargetSupportsCodecV2(prefix, target)
@@ -569,7 +569,7 @@ function Internal:UpdateBattleNetAccountData()
 		if CanExchangeWithGameAccount(account) then
 			local characterName = account.characterName
 			local realmName = string.gsub(account.realmName, "[%s*%-*]", "")
-			local mergedName = AddOn_Chomp.NameMergedRealm(characterName, realmName)
+			local mergedName = Chomp.NameMergedRealm(characterName, realmName)
 
 			self.bnetGameAccounts[mergedName] = account.gameAccountID
 		end
@@ -665,7 +665,7 @@ Internal:SetScript("OnEvent", function(self, event, ...)
 		end
 		if self.OutgoingQueue then
 			for i, q in ipairs(self.OutgoingQueue) do
-				AddOn_Chomp[q.f](unpack(q, 1, q.n))
+				Chomp[q.f](unpack(q, 1, q.n))
 			end
 			self.OutgoingQueue = nil
 		end

--- a/Public.lua
+++ b/Public.lua
@@ -15,11 +15,12 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-if not __chomp_internal or not __chomp_internal.LOADING then
+local Chomp = LibStub:GetLibrary("Chomp", true)
+local Internal = Chomp and Chomp.Internal or nil
+
+if not Chomp or not Internal or not Internal.LOADING then
 	return
 end
-
-local Internal = __chomp_internal
 
 local DEFAULT_PRIORITY = "MEDIUM"
 local PRIORITIES_HASH = { HIGH = true, MEDIUM = true, LOW = true }

--- a/Public.lua
+++ b/Public.lua
@@ -40,26 +40,26 @@ end
 
 function Chomp.SendAddonMessage(prefix, text, kind, target, priority, queue, callback, callbackArg)
 	if type(prefix) ~= "string" then
-		error("Chomp.SendAddonMessage(): prefix: expected string, got " .. type(prefix), 2)
+		error("Chomp.SendAddonMessage: prefix: expected string, got " .. type(prefix), 2)
 	elseif type(text) ~= "string" then
-		error("Chomp.SendAddonMessage(): text: expected string, got " .. type(text), 2)
+		error("Chomp.SendAddonMessage: text: expected string, got " .. type(text), 2)
 	elseif kind == "WHISPER" and type(target) ~= "string" then
-		error("Chomp.SendAddonMessage(): target: expected string, got " .. type(target), 2)
+		error("Chomp.SendAddonMessage: target: expected string, got " .. type(target), 2)
 	elseif kind == "CHANNEL" and type(target) ~= "number" then
-		error("Chomp.SendAddonMessage(): target: expected number, got " .. type(target), 2)
+		error("Chomp.SendAddonMessage: target: expected number, got " .. type(target), 2)
 	elseif priority and not PRIORITIES_HASH[priority] then
-		error("Chomp.SendAddonMessage(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
+		error("Chomp.SendAddonMessage: priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
 	elseif queue and type(queue) ~= "string" then
-		error("Chomp.SendAddonMessage(): queue: expected string or nil, got " .. type(queue), 2)
+		error("Chomp.SendAddonMessage: queue: expected string or nil, got " .. type(queue), 2)
 	elseif callback and type(callback) ~= "function" then
-		error("Chomp.SendAddonMessage(): callback: expected function or nil, got " .. type(callback), 2)
+		error("Chomp.SendAddonMessage: callback: expected function or nil, got " .. type(callback), 2)
 	end
 
 	local length = #text
 	if length > 255 then
-		error("Chomp.SendAddonMessage(): text length cannot exceed 255 bytes", 2)
+		error("Chomp.SendAddonMessage: text length cannot exceed 255 bytes", 2)
 	elseif #prefix > 16 then
-		error("Chomp.SendAddonMessage(): prefix: length cannot exceed 16 bytes", 2)
+		error("Chomp.SendAddonMessage: prefix: length cannot exceed 16 bytes", 2)
 	end
 	if not Internal.isReady then
 		QueueMessageOut("SendAddonMessage", prefix, text, kind, target, priority, queue, callback, callbackArg)
@@ -114,26 +114,26 @@ end
 
 function Chomp.SendAddonMessageLogged(prefix, text, kind, target, priority, queue, callback, callbackArg)
 	if type(prefix) ~= "string" then
-		error("Chomp.SendAddonMessageLogged(): prefix: expected string, got " .. type(prefix), 2)
+		error("Chomp.SendAddonMessageLogged: prefix: expected string, got " .. type(prefix), 2)
 	elseif type(text) ~= "string" then
-		error("Chomp.SendAddonMessageLogged(): text: expected string, got " .. type(text), 2)
+		error("Chomp.SendAddonMessageLogged: text: expected string, got " .. type(text), 2)
 	elseif kind == "WHISPER" and type(target) ~= "string" then
-		error("Chomp.SendAddonMessageLogged(): target: expected string, got " .. type(target), 2)
+		error("Chomp.SendAddonMessageLogged: target: expected string, got " .. type(target), 2)
 	elseif kind == "CHANNEL" and type(target) ~= "number" then
-		error("Chomp.SendAddonMessageLogged(): target: expected number, got " .. type(target), 2)
+		error("Chomp.SendAddonMessageLogged: target: expected number, got " .. type(target), 2)
 	elseif priority and not PRIORITIES_HASH[priority] then
-		error("Chomp.SendAddonMessageLogged(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
+		error("Chomp.SendAddonMessageLogged: priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
 	elseif queue and type(queue) ~= "string" then
-		error("Chomp.SendAddonMessageLogged(): queue: expected string or nil, got " .. type(queue), 2)
+		error("Chomp.SendAddonMessageLogged: queue: expected string or nil, got " .. type(queue), 2)
 	elseif callback and type(callback) ~= "function" then
-		error("Chomp.SendAddonMessageLogged(): callback: expected function or nil, got " .. type(callback), 2)
+		error("Chomp.SendAddonMessageLogged: callback: expected function or nil, got " .. type(callback), 2)
 	end
 
 	local length = #text
 	if length > 255 then
-		error("Chomp.SendAddonMessageLogged(): text length cannot exceed 255 bytes", 2)
+		error("Chomp.SendAddonMessageLogged: text length cannot exceed 255 bytes", 2)
 	elseif #prefix > 16 then
-		error("Chomp.SendAddonMessageLogged(): prefix: length cannot exceed 16 bytes", 2)
+		error("Chomp.SendAddonMessageLogged: prefix: length cannot exceed 16 bytes", 2)
 	end
 	if not Internal.isReady then
 		QueueMessageOut("SendAddonMessageLogged", prefix, text, kind, target, priority, queue, callback, callbackArg)
@@ -188,24 +188,24 @@ end
 
 function Chomp.SendChatMessage(text, kind, language, target, priority, queue, callback, callbackArg)
 	if type(text) ~= "string" then
-		error("Chomp.SendChatMessage(): text: expected string, got " .. type(text), 2)
+		error("Chomp.SendChatMessage: text: expected string, got " .. type(text), 2)
 	elseif language and type(language) ~= "string" and type(language) ~= "number" then
-		error("Chomp.SendChatMessage(): language: expected string or number, got " .. type(language), 2)
+		error("Chomp.SendChatMessage: language: expected string or number, got " .. type(language), 2)
 	elseif kind == "WHISPER" and type(target) ~= "string" then
-		error("Chomp.SendChatMessage(): target: expected string, got " .. type(target), 2)
+		error("Chomp.SendChatMessage: target: expected string, got " .. type(target), 2)
 	elseif kind == "CHANNEL" and type(target) ~= "number" then
-		error("Chomp.SendChatMessage(): target: expected number, got " .. type(target), 2)
+		error("Chomp.SendChatMessage: target: expected number, got " .. type(target), 2)
 	elseif priority and not PRIORITIES_HASH[priority] then
-		error("Chomp.SendChatMessage(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
+		error("Chomp.SendChatMessage: priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
 	elseif queue and type(queue) ~= "string" then
-		error("Chomp.SendChatMessage(): queue: expected string or nil, got " .. type(queue), 2)
+		error("Chomp.SendChatMessage: queue: expected string or nil, got " .. type(queue), 2)
 	elseif callback and type(callback) ~= "function" then
-		error("Chomp.SendChatMessage(): callback: expected function or nil, got " .. type(callback), 2)
+		error("Chomp.SendChatMessage: callback: expected function or nil, got " .. type(callback), 2)
 	end
 
 	local length = #text
 	if length > 255 then
-		error("Chomp.SendChatMessage(): text length cannot exceed 255 bytes", 2)
+		error("Chomp.SendChatMessage: text length cannot exceed 255 bytes", 2)
 	end
 	if not Internal.isReady then
 		QueueMessageOut("SendChatMessage", text, kind, language, target, priority, queue, callback, callbackArg)
@@ -260,24 +260,24 @@ end
 
 function Chomp.BNSendGameData(bnetIDGameAccount, prefix, text, priority, queue, callback, callbackArg)
 	if type(prefix) ~= "string" then
-		error("Chomp.BNSendGameData(): prefix: expected string, got " .. type(text), 2)
+		error("Chomp.BNSendGameData: prefix: expected string, got " .. type(text), 2)
 	elseif type(text) ~= "string" then
-		error("Chomp.BNSendGameData(): text: expected string, got " .. type(text), 2)
+		error("Chomp.BNSendGameData: text: expected string, got " .. type(text), 2)
 	elseif type(bnetIDGameAccount) ~= "number" then
-		error("Chomp.BNSendGameData(): bnetIDGameAccount: expected number, got " .. type(bnetIDGameAccount), 2)
+		error("Chomp.BNSendGameData: bnetIDGameAccount: expected number, got " .. type(bnetIDGameAccount), 2)
 	elseif priority and not PRIORITIES_HASH[priority] then
-		error("Chomp.BNSendGameData(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
+		error("Chomp.BNSendGameData: priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
 	elseif queue and type(queue) ~= "string" then
-		error("Chomp.BNSendGameData(): queue: expected string or nil, got " .. type(queue), 2)
+		error("Chomp.BNSendGameData: queue: expected string or nil, got " .. type(queue), 2)
 	elseif callback and type(callback) ~= "function" then
-		error("Chomp.BNSendGameData(): callback: expected function or nil, got " .. type(callback), 2)
+		error("Chomp.BNSendGameData: callback: expected function or nil, got " .. type(callback), 2)
 	end
 
 	local length = #text
 	if length > 4078 then
-		error("Chomp.BNSendGameData(): text: length cannot exceed 4078 bytes", 2)
+		error("Chomp.BNSendGameData: text: length cannot exceed 4078 bytes", 2)
 	elseif #prefix > 16 then
-		error("Chomp.BNSendGameData(): prefix: length cannot exceed 16 bytes", 2)
+		error("Chomp.BNSendGameData: prefix: length cannot exceed 16 bytes", 2)
 	end
 
 	if not Internal.isReady then
@@ -313,20 +313,20 @@ end
 
 function Chomp.BNSendWhisper(bnetIDAccount, text, priority, queue, callback, callbackArg)
 	if type(text) ~= "string" then
-		error("Chomp.BNSendWhisper(): text: expected string, got " .. type(text), 2)
+		error("Chomp.BNSendWhisper: text: expected string, got " .. type(text), 2)
 	elseif type(bnetIDAccount) ~= "number" then
-		error("Chomp.BNSendWhisper(): bnetIDAccount: expected number, got " .. type(bnetIDAccount), 2)
+		error("Chomp.BNSendWhisper: bnetIDAccount: expected number, got " .. type(bnetIDAccount), 2)
 	elseif priority and not PRIORITIES_HASH[priority] then
-		error("Chomp.BNSendWhisper(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
+		error("Chomp.BNSendWhisper: priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
 	elseif queue and type(queue) ~= "string" then
-		error("Chomp.BNSendWhisper(): queue: expected string or nil, got " .. type(queue), 2)
+		error("Chomp.BNSendWhisper: queue: expected string or nil, got " .. type(queue), 2)
 	elseif callback and type(callback) ~= "function" then
-		error("Chomp.BNSendWhisper(): callback: expected function or nil, got " .. type(callback), 2)
+		error("Chomp.BNSendWhisper: callback: expected function or nil, got " .. type(callback), 2)
 	end
 
 	local length = #text
 	if length > 997 then
-		error("Chomp.BNSendWhisper(): text length cannot exceed 997 bytes", 2)
+		error("Chomp.BNSendWhisper: text length cannot exceed 997 bytes", 2)
 	end
 
 	if not Internal.isReady then
@@ -372,21 +372,21 @@ local DEFAULT_SETTINGS = {
 function Chomp.RegisterAddonPrefix(prefix, callback, prefixSettings)
 	local prefixType = type(prefix)
 	if prefixType ~= "string" then
-		error("Chomp.RegisterAddonPrefix(): prefix: expected string, got " .. prefixType, 2)
+		error("Chomp.RegisterAddonPrefix: prefix: expected string, got " .. prefixType, 2)
 	elseif prefixType == "string" and #prefix > 16 then
-		error("Chomp.RegisterAddonPrefix(): prefix: length cannot exceed 16 bytes", 2)
+		error("Chomp.RegisterAddonPrefix: prefix: length cannot exceed 16 bytes", 2)
 	elseif type(callback) ~= "function" then
-		error("Chomp.RegisterAddonPrefix(): callback: expected function, got " .. type(callback), 2)
+		error("Chomp.RegisterAddonPrefix: callback: expected function, got " .. type(callback), 2)
 	elseif prefixSettings and type(prefixSettings) ~= "table" then
-		error("Chomp.RegisterAddonPrefix(): prefixSettings: expected table or nil, got " .. type(prefixSettings), 2)
+		error("Chomp.RegisterAddonPrefix: prefixSettings: expected table or nil, got " .. type(prefixSettings), 2)
 	end
 	if not prefixSettings then
 		prefixSettings = DEFAULT_SETTINGS
 	end
 	if prefixSettings.validTypes and type(prefixSettings.validTypes) ~= "table" then
-		error("Chomp.RegisterAddonPrefix(): prefixSettings.validTypes: expected table or nil, got " .. type(prefixSettings.validTypes), 2)
+		error("Chomp.RegisterAddonPrefix: prefixSettings.validTypes: expected table or nil, got " .. type(prefixSettings.validTypes), 2)
 	elseif prefixSettings.rawCallback and type(prefixSettings.rawCallback) ~= "function" then
-		error("Chomp.RegisterAddonPrefix(): prefixSettings.rawCallback: expected function or nil, got " .. type(prefixSettings.rawCallback), 2)
+		error("Chomp.RegisterAddonPrefix: prefixSettings.rawCallback: expected function or nil, got " .. type(prefixSettings.rawCallback), 2)
 	end
 	local prefixData = Internal.Prefixes[prefix]
 	if not prefixData then
@@ -408,7 +408,7 @@ function Chomp.RegisterAddonPrefix(prefix, callback, prefixSettings)
 			C_ChatInfo.RegisterAddonMessagePrefix(prefix)
 		end
 	else
-		error("Chomp.RegisterAddonPrefix(): prefix handler already registered, Chomp currently supports only one handler per prefix")
+		error("Chomp.RegisterAddonPrefix: prefix handler already registered, Chomp currently supports only one handler per prefix")
 	end
 end
 
@@ -464,15 +464,15 @@ local DEFAULT_OPTIONS = {}
 function Chomp.SmartAddonMessage(prefix, data, kind, target, messageOptions)
 	local prefixData = Internal.Prefixes[prefix]
 	if not prefixData then
-		error("Chomp.SmartAddonMessage(): prefix: prefix has not been registered with Chomp", 2)
+		error("Chomp.SmartAddonMessage: prefix: prefix has not been registered with Chomp", 2)
 	elseif type(kind) ~= "string" then
-		error("Chomp.SmartAddonMessage(): kind: expected string, got " .. type(kind), 2)
+		error("Chomp.SmartAddonMessage: kind: expected string, got " .. type(kind), 2)
 	elseif kind == "WHISPER" and type(target) ~= "string" then
-		error("Chomp.SmartAddonMessage(): target: expected string, got " .. type(target), 2)
+		error("Chomp.SmartAddonMessage: target: expected string, got " .. type(target), 2)
 	elseif kind == "CHANNEL" and type(target) ~= "number" then
-		error("Chomp.SmartAddonMessage(): target: expected number, got " .. type(target), 2)
+		error("Chomp.SmartAddonMessage: target: expected number, got " .. type(target), 2)
 	elseif target and kind ~= "WHISPER" and kind ~= "CHANNEL" then
-		error("Chomp.SmartAddonMessage(): target: expected nil, got " .. type(target), 2)
+		error("Chomp.SmartAddonMessage: target: expected nil, got " .. type(target), 2)
 	end
 
 	if not messageOptions then
@@ -481,13 +481,13 @@ function Chomp.SmartAddonMessage(prefix, data, kind, target, messageOptions)
 
 	local dataType = type(data)
 	if not prefixData.validTypes[dataType] then
-		error("Chomp.SmartAddonMessage(): data: type not registered as valid: " .. dataType, 2)
+		error("Chomp.SmartAddonMessage: data: type not registered as valid: " .. dataType, 2)
 	elseif dataType ~= "string" and not messageOptions.serialize then
-		error("Chomp.SmartAddonMessage(): data: no serialization requested, but serialization required for type: " .. dataType, 2)
+		error("Chomp.SmartAddonMessage: data: no serialization requested, but serialization required for type: " .. dataType, 2)
 	elseif messageOptions.priority and not PRIORITIES_HASH[messageOptions.priority] then
-		error("Chomp.SmartAddonMessage(): messageOptions.priority: expected \"HIGH\", \"MEDIUM\", or \"LOW\", got " .. tostring(messageOptions.priority), 2)
+		error("Chomp.SmartAddonMessage: messageOptions.priority: expected \"HIGH\", \"MEDIUM\", or \"LOW\", got " .. tostring(messageOptions.priority), 2)
 	elseif messageOptions.queue and type(messageOptions.queue) ~= "string" then
-		error("Chomp.SmartAddonMessage(): messageOptions.queue: expected string or nil, got " .. type(messageOptions.queue), 2)
+		error("Chomp.SmartAddonMessage: messageOptions.queue: expected string or nil, got " .. type(messageOptions.queue), 2)
 	end
 
 	if not Internal.isReady then
@@ -505,7 +505,7 @@ function Chomp.SmartAddonMessage(prefix, data, kind, target, messageOptions)
 	if not messageOptions.binaryBlob then
 		local permitted, reason = Chomp.CheckLoggedContents(data)
 		if not permitted then
-			error(("Chomp.SmartAddonMessage(): data: messageOptions.binaryBlob not specified, but disallowed sequences found, code: %s"):format(reason), 2)
+			error(("Chomp.SmartAddonMessage: data: messageOptions.binaryBlob not specified, but disallowed sequences found, code: %s"):format(reason), 2)
 		end
 	end
 
@@ -559,11 +559,11 @@ local ReportLocation = CreateFromMixins(PlayerLocationMixin)
 function Chomp.CheckReportGUID(prefix, guid)
 	local prefixData = Internal.Prefixes[prefix]
 	if type(prefix) ~= "string" then
-		error("Chomp.CheckReportGUID(): prefix: expected string, got " .. type(prefix), 2)
+		error("Chomp.CheckReportGUID: prefix: expected string, got " .. type(prefix), 2)
 	elseif type(guid) ~= "string" then
-		error("Chomp.CheckReportGUID(): guid: expected string, got " .. type(guid), 2)
+		error("Chomp.CheckReportGUID: guid: expected string, got " .. type(guid), 2)
 	elseif not prefixData then
-		error("Chomp.CheckReportGUID(): prefix: prefix has not been registered with Chomp", 2)
+		error("Chomp.CheckReportGUID: prefix: prefix has not been registered with Chomp", 2)
 	end
 	local success, _, _, _, _, _, name, realm = pcall(GetPlayerInfoByGUID, guid)
 	if not success or not name or name == UNKNOWNOBJECT then
@@ -584,13 +584,13 @@ end
 function Chomp.ReportGUID(prefix, guid, customMessage)
 	local prefixData = Internal.Prefixes[prefix]
 	if type(prefix) ~= "string" then
-		error("Chomp.ReportGUID(): prefix: expected string, got " .. type(prefix), 2)
+		error("Chomp.ReportGUID: prefix: expected string, got " .. type(prefix), 2)
 	elseif customMessage and type(customMessage) ~= "string" then
-		error("Chomp.ReportGUID(): customMessage: expected string, got " .. type(customMessage), 2)
+		error("Chomp.ReportGUID: customMessage: expected string, got " .. type(customMessage), 2)
 	elseif type(guid) ~= "string" then
-		error("Chomp.ReportGUID(): guid: expected string, got " .. type(guid), 2)
+		error("Chomp.ReportGUID: guid: expected string, got " .. type(guid), 2)
 	elseif not prefixData then
-		error("Chomp.ReportGUID(): prefix: prefix has not been registered with Chomp", 2)
+		error("Chomp.ReportGUID: prefix: prefix has not been registered with Chomp", 2)
 	end
 	local canReport, reason = Chomp.CheckReportGUID(prefix, guid)
 	if canReport then
@@ -693,9 +693,9 @@ end
 
 function Chomp.SetBPS(bps, burst)
 	if type(bps) ~= "number" then
-		error("Chomp.SetBPS(): bps: expected number, got " .. type(bps), 2)
+		error("Chomp.SetBPS: bps: expected number, got " .. type(bps), 2)
 	elseif type(burst) ~= "number" then
-		error("Chomp.SetBPS(): burst: expected number, got " .. type(burst), 2)
+		error("Chomp.SetBPS: burst: expected number, got " .. type(burst), 2)
 	end
 	Internal.BPS = bps
 	Internal.BURST = burst

--- a/Public.lua
+++ b/Public.lua
@@ -38,28 +38,28 @@ local function QueueMessageOut(func, ...)
 	q[#q + 1] = t
 end
 
-function AddOn_Chomp.SendAddonMessage(prefix, text, kind, target, priority, queue, callback, callbackArg)
+function Chomp.SendAddonMessage(prefix, text, kind, target, priority, queue, callback, callbackArg)
 	if type(prefix) ~= "string" then
-		error("AddOn_Chomp.SendAddonMessage(): prefix: expected string, got " .. type(prefix), 2)
+		error("Chomp.SendAddonMessage(): prefix: expected string, got " .. type(prefix), 2)
 	elseif type(text) ~= "string" then
-		error("AddOn_Chomp.SendAddonMessage(): text: expected string, got " .. type(text), 2)
+		error("Chomp.SendAddonMessage(): text: expected string, got " .. type(text), 2)
 	elseif kind == "WHISPER" and type(target) ~= "string" then
-		error("AddOn_Chomp.SendAddonMessage(): target: expected string, got " .. type(target), 2)
+		error("Chomp.SendAddonMessage(): target: expected string, got " .. type(target), 2)
 	elseif kind == "CHANNEL" and type(target) ~= "number" then
-		error("AddOn_Chomp.SendAddonMessage(): target: expected number, got " .. type(target), 2)
+		error("Chomp.SendAddonMessage(): target: expected number, got " .. type(target), 2)
 	elseif priority and not PRIORITIES_HASH[priority] then
-		error("AddOn_Chomp.SendAddonMessage(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
+		error("Chomp.SendAddonMessage(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
 	elseif queue and type(queue) ~= "string" then
-		error("AddOn_Chomp.SendAddonMessage(): queue: expected string or nil, got " .. type(queue), 2)
+		error("Chomp.SendAddonMessage(): queue: expected string or nil, got " .. type(queue), 2)
 	elseif callback and type(callback) ~= "function" then
-		error("AddOn_Chomp.SendAddonMessage(): callback: expected function or nil, got " .. type(callback), 2)
+		error("Chomp.SendAddonMessage(): callback: expected function or nil, got " .. type(callback), 2)
 	end
 
 	local length = #text
 	if length > 255 then
-		error("AddOn_Chomp.SendAddonMessage(): text length cannot exceed 255 bytes", 2)
+		error("Chomp.SendAddonMessage(): text length cannot exceed 255 bytes", 2)
 	elseif #prefix > 16 then
-		error("AddOn_Chomp.SendAddonMessage(): prefix: length cannot exceed 16 bytes", 2)
+		error("Chomp.SendAddonMessage(): prefix: length cannot exceed 16 bytes", 2)
 	end
 	if not Internal.isReady then
 		QueueMessageOut("SendAddonMessage", prefix, text, kind, target, priority, queue, callback, callbackArg)
@@ -112,28 +112,28 @@ function AddOn_Chomp.SendAddonMessage(prefix, text, kind, target, priority, queu
 	return Internal:Enqueue(priority or DEFAULT_PRIORITY, queue or ("%s%s%s"):format(prefix, kind, (tostring(target) or "")), message)
 end
 
-function AddOn_Chomp.SendAddonMessageLogged(prefix, text, kind, target, priority, queue, callback, callbackArg)
+function Chomp.SendAddonMessageLogged(prefix, text, kind, target, priority, queue, callback, callbackArg)
 	if type(prefix) ~= "string" then
-		error("AddOn_Chomp.SendAddonMessageLogged(): prefix: expected string, got " .. type(prefix), 2)
+		error("Chomp.SendAddonMessageLogged(): prefix: expected string, got " .. type(prefix), 2)
 	elseif type(text) ~= "string" then
-		error("AddOn_Chomp.SendAddonMessageLogged(): text: expected string, got " .. type(text), 2)
+		error("Chomp.SendAddonMessageLogged(): text: expected string, got " .. type(text), 2)
 	elseif kind == "WHISPER" and type(target) ~= "string" then
-		error("AddOn_Chomp.SendAddonMessageLogged(): target: expected string, got " .. type(target), 2)
+		error("Chomp.SendAddonMessageLogged(): target: expected string, got " .. type(target), 2)
 	elseif kind == "CHANNEL" and type(target) ~= "number" then
-		error("AddOn_Chomp.SendAddonMessageLogged(): target: expected number, got " .. type(target), 2)
+		error("Chomp.SendAddonMessageLogged(): target: expected number, got " .. type(target), 2)
 	elseif priority and not PRIORITIES_HASH[priority] then
-		error("AddOn_Chomp.SendAddonMessageLogged(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
+		error("Chomp.SendAddonMessageLogged(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
 	elseif queue and type(queue) ~= "string" then
-		error("AddOn_Chomp.SendAddonMessageLogged(): queue: expected string or nil, got " .. type(queue), 2)
+		error("Chomp.SendAddonMessageLogged(): queue: expected string or nil, got " .. type(queue), 2)
 	elseif callback and type(callback) ~= "function" then
-		error("AddOn_Chomp.SendAddonMessageLogged(): callback: expected function or nil, got " .. type(callback), 2)
+		error("Chomp.SendAddonMessageLogged(): callback: expected function or nil, got " .. type(callback), 2)
 	end
 
 	local length = #text
 	if length > 255 then
-		error("AddOn_Chomp.SendAddonMessageLogged(): text length cannot exceed 255 bytes", 2)
+		error("Chomp.SendAddonMessageLogged(): text length cannot exceed 255 bytes", 2)
 	elseif #prefix > 16 then
-		error("AddOn_Chomp.SendAddonMessageLogged(): prefix: length cannot exceed 16 bytes", 2)
+		error("Chomp.SendAddonMessageLogged(): prefix: length cannot exceed 16 bytes", 2)
 	end
 	if not Internal.isReady then
 		QueueMessageOut("SendAddonMessageLogged", prefix, text, kind, target, priority, queue, callback, callbackArg)
@@ -186,26 +186,26 @@ function AddOn_Chomp.SendAddonMessageLogged(prefix, text, kind, target, priority
 	return Internal:Enqueue(priority or DEFAULT_PRIORITY, queue or ("%s%s%s"):format(prefix, kind, (tostring(target) or "")), message)
 end
 
-function AddOn_Chomp.SendChatMessage(text, kind, language, target, priority, queue, callback, callbackArg)
+function Chomp.SendChatMessage(text, kind, language, target, priority, queue, callback, callbackArg)
 	if type(text) ~= "string" then
-		error("AddOn_Chomp.SendChatMessage(): text: expected string, got " .. type(text), 2)
+		error("Chomp.SendChatMessage(): text: expected string, got " .. type(text), 2)
 	elseif language and type(language) ~= "string" and type(language) ~= "number" then
-		error("AddOn_Chomp.SendChatMessage(): language: expected string or number, got " .. type(language), 2)
+		error("Chomp.SendChatMessage(): language: expected string or number, got " .. type(language), 2)
 	elseif kind == "WHISPER" and type(target) ~= "string" then
-		error("AddOn_Chomp.SendChatMessage(): target: expected string, got " .. type(target), 2)
+		error("Chomp.SendChatMessage(): target: expected string, got " .. type(target), 2)
 	elseif kind == "CHANNEL" and type(target) ~= "number" then
-		error("AddOn_Chomp.SendChatMessage(): target: expected number, got " .. type(target), 2)
+		error("Chomp.SendChatMessage(): target: expected number, got " .. type(target), 2)
 	elseif priority and not PRIORITIES_HASH[priority] then
-		error("AddOn_Chomp.SendChatMessage(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
+		error("Chomp.SendChatMessage(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
 	elseif queue and type(queue) ~= "string" then
-		error("AddOn_Chomp.SendChatMessage(): queue: expected string or nil, got " .. type(queue), 2)
+		error("Chomp.SendChatMessage(): queue: expected string or nil, got " .. type(queue), 2)
 	elseif callback and type(callback) ~= "function" then
-		error("AddOn_Chomp.SendChatMessage(): callback: expected function or nil, got " .. type(callback), 2)
+		error("Chomp.SendChatMessage(): callback: expected function or nil, got " .. type(callback), 2)
 	end
 
 	local length = #text
 	if length > 255 then
-		error("AddOn_Chomp.SendChatMessage(): text length cannot exceed 255 bytes", 2)
+		error("Chomp.SendChatMessage(): text length cannot exceed 255 bytes", 2)
 	end
 	if not Internal.isReady then
 		QueueMessageOut("SendChatMessage", text, kind, language, target, priority, queue, callback, callbackArg)
@@ -258,26 +258,26 @@ function AddOn_Chomp.SendChatMessage(text, kind, language, target, priority, que
 	return Internal:Enqueue(priority or DEFAULT_PRIORITY, queue or kind .. (target or ""), message)
 end
 
-function AddOn_Chomp.BNSendGameData(bnetIDGameAccount, prefix, text, priority, queue, callback, callbackArg)
+function Chomp.BNSendGameData(bnetIDGameAccount, prefix, text, priority, queue, callback, callbackArg)
 	if type(prefix) ~= "string" then
-		error("AddOn_Chomp.BNSendGameData(): prefix: expected string, got " .. type(text), 2)
+		error("Chomp.BNSendGameData(): prefix: expected string, got " .. type(text), 2)
 	elseif type(text) ~= "string" then
-		error("AddOn_Chomp.BNSendGameData(): text: expected string, got " .. type(text), 2)
+		error("Chomp.BNSendGameData(): text: expected string, got " .. type(text), 2)
 	elseif type(bnetIDGameAccount) ~= "number" then
-		error("AddOn_Chomp.BNSendGameData(): bnetIDGameAccount: expected number, got " .. type(bnetIDGameAccount), 2)
+		error("Chomp.BNSendGameData(): bnetIDGameAccount: expected number, got " .. type(bnetIDGameAccount), 2)
 	elseif priority and not PRIORITIES_HASH[priority] then
-		error("AddOn_Chomp.BNSendGameData(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
+		error("Chomp.BNSendGameData(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
 	elseif queue and type(queue) ~= "string" then
-		error("AddOn_Chomp.BNSendGameData(): queue: expected string or nil, got " .. type(queue), 2)
+		error("Chomp.BNSendGameData(): queue: expected string or nil, got " .. type(queue), 2)
 	elseif callback and type(callback) ~= "function" then
-		error("AddOn_Chomp.BNSendGameData(): callback: expected function or nil, got " .. type(callback), 2)
+		error("Chomp.BNSendGameData(): callback: expected function or nil, got " .. type(callback), 2)
 	end
 
 	local length = #text
 	if length > 4078 then
-		error("AddOn_Chomp.BNSendGameData(): text: length cannot exceed 4078 bytes", 2)
+		error("Chomp.BNSendGameData(): text: length cannot exceed 4078 bytes", 2)
 	elseif #prefix > 16 then
-		error("AddOn_Chomp.BNSendGameData(): prefix: length cannot exceed 16 bytes", 2)
+		error("Chomp.BNSendGameData(): prefix: length cannot exceed 16 bytes", 2)
 	end
 
 	if not Internal.isReady then
@@ -311,22 +311,22 @@ function AddOn_Chomp.BNSendGameData(bnetIDGameAccount, prefix, text, priority, q
 	return Internal:Enqueue(priority or DEFAULT_PRIORITY, queue or ("%s%d"):format(prefix, bnetIDGameAccount), message)
 end
 
-function AddOn_Chomp.BNSendWhisper(bnetIDAccount, text, priority, queue, callback, callbackArg)
+function Chomp.BNSendWhisper(bnetIDAccount, text, priority, queue, callback, callbackArg)
 	if type(text) ~= "string" then
-		error("AddOn_Chomp.BNSendWhisper(): text: expected string, got " .. type(text), 2)
+		error("Chomp.BNSendWhisper(): text: expected string, got " .. type(text), 2)
 	elseif type(bnetIDAccount) ~= "number" then
-		error("AddOn_Chomp.BNSendWhisper(): bnetIDAccount: expected number, got " .. type(bnetIDAccount), 2)
+		error("Chomp.BNSendWhisper(): bnetIDAccount: expected number, got " .. type(bnetIDAccount), 2)
 	elseif priority and not PRIORITIES_HASH[priority] then
-		error("AddOn_Chomp.BNSendWhisper(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
+		error("Chomp.BNSendWhisper(): priority: expected \"HIGH\", \"MEDIUM\", \"LOW\", or nil, got " .. tostring(priority), 2)
 	elseif queue and type(queue) ~= "string" then
-		error("AddOn_Chomp.BNSendWhisper(): queue: expected string or nil, got " .. type(queue), 2)
+		error("Chomp.BNSendWhisper(): queue: expected string or nil, got " .. type(queue), 2)
 	elseif callback and type(callback) ~= "function" then
-		error("AddOn_Chomp.BNSendWhisper(): callback: expected function or nil, got " .. type(callback), 2)
+		error("Chomp.BNSendWhisper(): callback: expected function or nil, got " .. type(callback), 2)
 	end
 
 	local length = #text
 	if length > 997 then
-		error("AddOn_Chomp.BNSendWhisper(): text length cannot exceed 997 bytes", 2)
+		error("Chomp.BNSendWhisper(): text length cannot exceed 997 bytes", 2)
 	end
 
 	if not Internal.isReady then
@@ -359,7 +359,7 @@ function AddOn_Chomp.BNSendWhisper(bnetIDAccount, text, priority, queue, callbac
 	return Internal:Enqueue(priority or DEFAULT_PRIORITY, queue or tostring(bnetIDAccount), message)
 end
 
-function AddOn_Chomp.IsSending()
+function Chomp.IsSending()
 	return Internal.isSending
 end
 
@@ -369,24 +369,24 @@ local DEFAULT_SETTINGS = {
 		["string"] = true,
 	},
 }
-function AddOn_Chomp.RegisterAddonPrefix(prefix, callback, prefixSettings)
+function Chomp.RegisterAddonPrefix(prefix, callback, prefixSettings)
 	local prefixType = type(prefix)
 	if prefixType ~= "string" then
-		error("AddOn_Chomp.RegisterAddonPrefix(): prefix: expected string, got " .. prefixType, 2)
+		error("Chomp.RegisterAddonPrefix(): prefix: expected string, got " .. prefixType, 2)
 	elseif prefixType == "string" and #prefix > 16 then
-		error("AddOn_Chomp.RegisterAddonPrefix(): prefix: length cannot exceed 16 bytes", 2)
+		error("Chomp.RegisterAddonPrefix(): prefix: length cannot exceed 16 bytes", 2)
 	elseif type(callback) ~= "function" then
-		error("AddOn_Chomp.RegisterAddonPrefix(): callback: expected function, got " .. type(callback), 2)
+		error("Chomp.RegisterAddonPrefix(): callback: expected function, got " .. type(callback), 2)
 	elseif prefixSettings and type(prefixSettings) ~= "table" then
-		error("AddOn_Chomp.RegisterAddonPrefix(): prefixSettings: expected table or nil, got " .. type(prefixSettings), 2)
+		error("Chomp.RegisterAddonPrefix(): prefixSettings: expected table or nil, got " .. type(prefixSettings), 2)
 	end
 	if not prefixSettings then
 		prefixSettings = DEFAULT_SETTINGS
 	end
 	if prefixSettings.validTypes and type(prefixSettings.validTypes) ~= "table" then
-		error("AddOn_Chomp.RegisterAddonPrefix(): prefixSettings.validTypes: expected table or nil, got " .. type(prefixSettings.validTypes), 2)
+		error("Chomp.RegisterAddonPrefix(): prefixSettings.validTypes: expected table or nil, got " .. type(prefixSettings.validTypes), 2)
 	elseif prefixSettings.rawCallback and type(prefixSettings.rawCallback) ~= "function" then
-		error("AddOn_Chomp.RegisterAddonPrefix(): prefixSettings.rawCallback: expected function or nil, got " .. type(prefixSettings.rawCallback), 2)
+		error("Chomp.RegisterAddonPrefix(): prefixSettings.rawCallback: expected function or nil, got " .. type(prefixSettings.rawCallback), 2)
 	end
 	local prefixData = Internal.Prefixes[prefix]
 	if not prefixData then
@@ -408,11 +408,11 @@ function AddOn_Chomp.RegisterAddonPrefix(prefix, callback, prefixSettings)
 			C_ChatInfo.RegisterAddonMessagePrefix(prefix)
 		end
 	else
-		error("AddOn_Chomp.RegisterAddonPrefix(): prefix handler already registered, Chomp currently supports only one handler per prefix")
+		error("Chomp.RegisterAddonPrefix(): prefix handler already registered, Chomp currently supports only one handler per prefix")
 	end
 end
 
-function AddOn_Chomp.IsAddonPrefixRegistered(prefix)
+function Chomp.IsAddonPrefixRegistered(prefix)
 	return Internal.Prefixes[prefix] ~= nil
 end
 
@@ -431,7 +431,7 @@ local function SplitAndSend(sendFunc, maxSize, bitField, prefix, text, ...)
 	while position <= textLen do
 		-- Only *need* to do a safe substring for encoded channels, but doing so
 		-- always shouldn't hurt.
-		local msgText, offset = AddOn_Chomp.SafeSubString(text, position, position + maxSize - 1, textLen, codecVersion)
+		local msgText, offset = Chomp.SafeSubString(text, position, position + maxSize - 1, textLen, codecVersion)
 		if offset > 0 then
 			-- Update total offset and total message number if needed.
 			totalOffset = totalOffset + offset
@@ -445,15 +445,15 @@ local function SplitAndSend(sendFunc, maxSize, bitField, prefix, text, ...)
 end
 
 local function ToInGame(bitField, prefix, text, kind, target, priority, queue)
-	return SplitAndSend(AddOn_Chomp.SendAddonMessage, 255, bitField, prefix, text, kind, target, priority, queue)
+	return SplitAndSend(Chomp.SendAddonMessage, 255, bitField, prefix, text, kind, target, priority, queue)
 end
 
 local function ToInGameLogged(bitField, prefix, text, kind, target, priority, queue)
-	return SplitAndSend(AddOn_Chomp.SendAddonMessageLogged, 255, bitField, prefix, text, kind, target, priority, queue)
+	return SplitAndSend(Chomp.SendAddonMessageLogged, 255, bitField, prefix, text, kind, target, priority, queue)
 end
 
 local function BNSendGameDataRearrange(prefix, text, bnetIDGameAccount, ...)
-	return AddOn_Chomp.BNSendGameData(bnetIDGameAccount, prefix, text, ...)
+	return Chomp.BNSendGameData(bnetIDGameAccount, prefix, text, ...)
 end
 
 local function ToBattleNet(bitField, prefix, text, kind, bnetIDGameAccount, priority, queue)
@@ -461,18 +461,18 @@ local function ToBattleNet(bitField, prefix, text, kind, bnetIDGameAccount, prio
 end
 
 local DEFAULT_OPTIONS = {}
-function AddOn_Chomp.SmartAddonMessage(prefix, data, kind, target, messageOptions)
+function Chomp.SmartAddonMessage(prefix, data, kind, target, messageOptions)
 	local prefixData = Internal.Prefixes[prefix]
 	if not prefixData then
-		error("AddOn_Chomp.SmartAddonMessage(): prefix: prefix has not been registered with Chomp", 2)
+		error("Chomp.SmartAddonMessage(): prefix: prefix has not been registered with Chomp", 2)
 	elseif type(kind) ~= "string" then
-		error("AddOn_Chomp.SmartAddonMessage(): kind: expected string, got " .. type(kind), 2)
+		error("Chomp.SmartAddonMessage(): kind: expected string, got " .. type(kind), 2)
 	elseif kind == "WHISPER" and type(target) ~= "string" then
-		error("AddOn_Chomp.SmartAddonMessage(): target: expected string, got " .. type(target), 2)
+		error("Chomp.SmartAddonMessage(): target: expected string, got " .. type(target), 2)
 	elseif kind == "CHANNEL" and type(target) ~= "number" then
-		error("AddOn_Chomp.SmartAddonMessage(): target: expected number, got " .. type(target), 2)
+		error("Chomp.SmartAddonMessage(): target: expected number, got " .. type(target), 2)
 	elseif target and kind ~= "WHISPER" and kind ~= "CHANNEL" then
-		error("AddOn_Chomp.SmartAddonMessage(): target: expected nil, got " .. type(target), 2)
+		error("Chomp.SmartAddonMessage(): target: expected nil, got " .. type(target), 2)
 	end
 
 	if not messageOptions then
@@ -481,13 +481,13 @@ function AddOn_Chomp.SmartAddonMessage(prefix, data, kind, target, messageOption
 
 	local dataType = type(data)
 	if not prefixData.validTypes[dataType] then
-		error("AddOn_Chomp.SmartAddonMessage(): data: type not registered as valid: " .. dataType, 2)
+		error("Chomp.SmartAddonMessage(): data: type not registered as valid: " .. dataType, 2)
 	elseif dataType ~= "string" and not messageOptions.serialize then
-		error("AddOn_Chomp.SmartAddonMessage(): data: no serialization requested, but serialization required for type: " .. dataType, 2)
+		error("Chomp.SmartAddonMessage(): data: no serialization requested, but serialization required for type: " .. dataType, 2)
 	elseif messageOptions.priority and not PRIORITIES_HASH[messageOptions.priority] then
-		error("AddOn_Chomp.SmartAddonMessage(): messageOptions.priority: expected \"HIGH\", \"MEDIUM\", or \"LOW\", got " .. tostring(messageOptions.priority), 2)
+		error("Chomp.SmartAddonMessage(): messageOptions.priority: expected \"HIGH\", \"MEDIUM\", or \"LOW\", got " .. tostring(messageOptions.priority), 2)
 	elseif messageOptions.queue and type(messageOptions.queue) ~= "string" then
-		error("AddOn_Chomp.SmartAddonMessage(): messageOptions.queue: expected string or nil, got " .. type(messageOptions.queue), 2)
+		error("Chomp.SmartAddonMessage(): messageOptions.queue: expected string or nil, got " .. type(messageOptions.queue), 2)
 	end
 
 	if not Internal.isReady then
@@ -500,17 +500,17 @@ function AddOn_Chomp.SmartAddonMessage(prefix, data, kind, target, messageOption
 
 	if messageOptions.serialize then
 		bitField = bit.bor(bitField, Internal.BITS.SERIALIZE)
-		data = AddOn_Chomp.Serialize(data)
+		data = Chomp.Serialize(data)
 	end
 	if not messageOptions.binaryBlob then
-		local permitted, reason = AddOn_Chomp.CheckLoggedContents(data)
+		local permitted, reason = Chomp.CheckLoggedContents(data)
 		if not permitted then
-			error(("AddOn_Chomp.SmartAddonMessage(): data: messageOptions.binaryBlob not specified, but disallowed sequences found, code: %s"):format(reason), 2)
+			error(("Chomp.SmartAddonMessage(): data: messageOptions.binaryBlob not specified, but disallowed sequences found, code: %s"):format(reason), 2)
 		end
 	end
 
 	if kind == "WHISPER" then
-		target = AddOn_Chomp.NameMergedRealm(target)
+		target = Chomp.NameMergedRealm(target)
 	end
 
 	local codecVersion
@@ -539,7 +539,7 @@ function AddOn_Chomp.SmartAddonMessage(prefix, data, kind, target, messageOption
 		if prefixData.broadcastPrefix and messageOptions.allowBroadcast and UnitRealmRelationship(targetUnit) == LE_REALM_RELATION_COALESCED then
 			bitField = bit.bor(bitField, Internal.BITS.BROADCAST)
 			kind = UnitInRaid(targetUnit, LE_PARTY_CATEGORY_HOME) and not UnitInSubgroup(targetUnit, LE_PARTY_CATEGORY_HOME) and "RAID" or UnitInParty(targetUnit, LE_PARTY_CATEGORY_HOME) and "PARTY" or "INSTANCE_CHAT"
-			data = ("%s\127%s"):format(not messageOptions.universalBroadcast and AddOn_Chomp.NameMergedRealm(target) or "", data)
+			data = ("%s\127%s"):format(not messageOptions.universalBroadcast and Chomp.NameMergedRealm(target) or "", data)
 			target = nil
 			if messageOptions.universalBroadcast then
 				queue = nil
@@ -556,20 +556,20 @@ end
 
 local ReportLocation = CreateFromMixins(PlayerLocationMixin)
 
-function AddOn_Chomp.CheckReportGUID(prefix, guid)
+function Chomp.CheckReportGUID(prefix, guid)
 	local prefixData = Internal.Prefixes[prefix]
 	if type(prefix) ~= "string" then
-		error("AddOn_Chomp.CheckReportGUID(): prefix: expected string, got " .. type(prefix), 2)
+		error("Chomp.CheckReportGUID(): prefix: expected string, got " .. type(prefix), 2)
 	elseif type(guid) ~= "string" then
-		error("AddOn_Chomp.CheckReportGUID(): guid: expected string, got " .. type(guid), 2)
+		error("Chomp.CheckReportGUID(): guid: expected string, got " .. type(guid), 2)
 	elseif not prefixData then
-		error("AddOn_Chomp.CheckReportGUID(): prefix: prefix has not been registered with Chomp", 2)
+		error("Chomp.CheckReportGUID(): prefix: prefix has not been registered with Chomp", 2)
 	end
 	local success, _, _, _, _, _, name, realm = pcall(GetPlayerInfoByGUID, guid)
 	if not success or not name or name == UNKNOWNOBJECT then
 		return false, "UNKNOWN"
 	end
-	local target = AddOn_Chomp.NameMergedRealm(name, realm)
+	local target = Chomp.NameMergedRealm(name, realm)
 	if Internal:GetBattleNetAccountID(target) then
 		return false, "BATTLENET"
 	end
@@ -581,18 +581,18 @@ function AddOn_Chomp.CheckReportGUID(prefix, guid)
 	end
 end
 
-function AddOn_Chomp.ReportGUID(prefix, guid, customMessage)
+function Chomp.ReportGUID(prefix, guid, customMessage)
 	local prefixData = Internal.Prefixes[prefix]
 	if type(prefix) ~= "string" then
-		error("AddOn_Chomp.ReportGUID(): prefix: expected string, got " .. type(prefix), 2)
+		error("Chomp.ReportGUID(): prefix: expected string, got " .. type(prefix), 2)
 	elseif customMessage and type(customMessage) ~= "string" then
-		error("AddOn_Chomp.ReportGUID(): customMessage: expected string, got " .. type(customMessage), 2)
+		error("Chomp.ReportGUID(): customMessage: expected string, got " .. type(customMessage), 2)
 	elseif type(guid) ~= "string" then
-		error("AddOn_Chomp.ReportGUID(): guid: expected string, got " .. type(guid), 2)
+		error("Chomp.ReportGUID(): guid: expected string, got " .. type(guid), 2)
 	elseif not prefixData then
-		error("AddOn_Chomp.ReportGUID(): prefix: prefix has not been registered with Chomp", 2)
+		error("Chomp.ReportGUID(): prefix: prefix has not been registered with Chomp", 2)
 	end
-	local canReport, reason = AddOn_Chomp.CheckReportGUID(prefix, guid)
+	local canReport, reason = Chomp.CheckReportGUID(prefix, guid)
 	if canReport then
 		if C_ReportSystem then
 			local _, _, _, _, _, name, realm = GetPlayerInfoByGUID(guid)
@@ -618,48 +618,48 @@ local function CopyValuesAsKeys(tbl)
 	return output
 end
 
-AddOn_Chomp.Event = CopyValuesAsKeys(
+Chomp.Event = CopyValuesAsKeys(
 	{
 		"OnMessageReceived",
 		"OnError",
 	}
 )
 
-function AddOn_Chomp.RegisterCallback(event, func, owner)
+function Chomp.RegisterCallback(event, func, owner)
 	if type(event) ~= "string" then
-		error("AddOn_Chomp.RegisterCallback: 'event' must be a string")
-	elseif not AddOn_Chomp.Event[event] then
-		error(string.format("AddOn_Chomp.RegisterCallback: event %q does not exist", event))
+		error("Chomp.RegisterCallback: 'event' must be a string")
+	elseif not Chomp.Event[event] then
+		error(string.format("Chomp.RegisterCallback: event %q does not exist", event))
 	elseif type(func) ~= "function" and type(func) ~= "table" then
-		error("AddOn_Chomp.RegisterCallback: 'func' must be callable")
+		error("Chomp.RegisterCallback: 'func' must be callable")
 	elseif type(owner) ~= "string" and type(owner) ~= "table" and type(owner) ~= "thread" then
-		error("AddOn_Chomp.RegisterCallback: 'owner' must be string, table, or coroutine")
+		error("Chomp.RegisterCallback: 'owner' must be string, table, or coroutine")
 	end
 
 	Internal.RegisterCallback(owner, event, function(_, ...) return func(owner, ...) end)
 end
 
-function AddOn_Chomp.UnregisterCallback(event, owner)
+function Chomp.UnregisterCallback(event, owner)
 	if type(event) ~= "string" then
-		error("AddOn_Chomp.UnregisterCallback: 'event' must be a string")
-	elseif not AddOn_Chomp.Event[event] then
-		error(string.format("AddOn_Chomp.UnregisterCallback: event %q does not exist", event))
+		error("Chomp.UnregisterCallback: 'event' must be a string")
+	elseif not Chomp.Event[event] then
+		error(string.format("Chomp.UnregisterCallback: event %q does not exist", event))
 	elseif type(owner) ~= "string" and type(owner) ~= "table" and type(owner) ~= "thread" then
-		error("AddOn_Chomp.UnregisterCallback: 'owner' must be string, table, or coroutine")
+		error("Chomp.UnregisterCallback: 'owner' must be string, table, or coroutine")
 	end
 
 	Internal.UnregisterCallback(owner, event)
 end
 
-function AddOn_Chomp.UnregisterAllCallbacks(owner)
+function Chomp.UnregisterAllCallbacks(owner)
 	if type(owner) ~= "string" and type(owner) ~= "table" and type(owner) ~= "thread" then
-		error("AddOn_Chomp.UnregisterAllCallbacks: 'owner' must be string, table, or coroutine")
+		error("Chomp.UnregisterAllCallbacks: 'owner' must be string, table, or coroutine")
 	end
 
 	Internal.UnregisterAllCallbacks(owner)
 end
 
-function AddOn_Chomp.RegisterErrorCallback(callback)
+function Chomp.RegisterErrorCallback(callback)
 	-- v18+: RegisterErrorCallback is deprecated in favor of the generic
 	--       RegisterCallback system.
 
@@ -667,40 +667,40 @@ function AddOn_Chomp.RegisterErrorCallback(callback)
 	local func  = function(_, ...) return callback(...) end
 	local owner = tostring(callback)
 
-	AddOn_Chomp.RegisterCallback(event, func, owner)
+	Chomp.RegisterCallback(event, func, owner)
 
 	return true
 end
 
-function AddOn_Chomp.UnregisterErrorCallback(callback)
+function Chomp.UnregisterErrorCallback(callback)
 	-- v18+: UnregisterErrorCallback is deprecated in favor of the generic
 	--       UnregisterCallback system.
 
 	local event = "OnError"
 	local owner = tostring(callback)
 
-	AddOn_Chomp.UnregisterCallback(event, owner)
+	Chomp.UnregisterCallback(event, owner)
 
 	return true
 end
 
 -- v18+: Deprecated alias for the old typo'd function name.
-AddOn_Chomp.UnegisterErrorCallback = AddOn_Chomp.UnregisterErrorCallback
+Chomp.UnegisterErrorCallback = Chomp.UnregisterErrorCallback
 
-function AddOn_Chomp.GetBPS()
+function Chomp.GetBPS()
 	return Internal.BPS, Internal.BURST
 end
 
-function AddOn_Chomp.SetBPS(bps, burst)
+function Chomp.SetBPS(bps, burst)
 	if type(bps) ~= "number" then
-		error("AddOn_Chomp.SetBPS(): bps: expected number, got " .. type(bps), 2)
+		error("Chomp.SetBPS(): bps: expected number, got " .. type(bps), 2)
 	elseif type(burst) ~= "number" then
-		error("AddOn_Chomp.SetBPS(): burst: expected number, got " .. type(burst), 2)
+		error("Chomp.SetBPS(): burst: expected number, got " .. type(burst), 2)
 	end
 	Internal.BPS = bps
 	Internal.BURST = burst
 end
 
-function AddOn_Chomp.GetVersion()
+function Chomp.GetVersion()
 	return Internal.VERSION
 end

--- a/StringManip.lua
+++ b/StringManip.lua
@@ -99,11 +99,11 @@ local CodecsByVersion = {
 local FULL_PLAYER_SPLIT = FULL_PLAYER_NAME:gsub("-", "%%%%-"):format("^(.-)", "(.+)$")
 local FULL_PLAYER_FIND = FULL_PLAYER_NAME:gsub("-", "%%%%-"):format("^.-", ".+$")
 
-function AddOn_Chomp.NameMergedRealm(name, realm)
+function Chomp.NameMergedRealm(name, realm)
 	if type(name) ~= "string" then
-		error("AddOn_Chomp.NameMergedRealm(): name: expected string, got " .. type(name), 2)
+		error("Chomp.NameMergedRealm(): name: expected string, got " .. type(name), 2)
 	elseif name == "" then
-		error("AddOn_Chomp.NameMergedRealm(): name: expected non-empty string", 2)
+		error("Chomp.NameMergedRealm(): name: expected non-empty string", 2)
 	elseif not realm or realm == "" then
 		-- Normally you'd just return the full input name without reformatting,
 		-- but Blizzard has started returning an occasional "Name-Realm Name"
@@ -116,12 +116,12 @@ function AddOn_Chomp.NameMergedRealm(name, realm)
 			realm = GetRealmName()
 		end
 	elseif name:find(FULL_PLAYER_FIND) then
-		error("AddOn_Chomp.NameMergedRealm(): name already has a realm name, but realm name also provided")
+		error("Chomp.NameMergedRealm(): name already has a realm name, but realm name also provided")
 	end
 	return FULL_PLAYER_NAME:format(name, (realm:gsub("[%s%-]", "")))
 end
 
-function AddOn_Chomp.NameSplitRealm(nameRealm)
+function Chomp.NameSplitRealm(nameRealm)
 	return string.match(nameRealm, FULL_PLAYER_SPLIT)
 end
 
@@ -192,14 +192,14 @@ end
 
 Internal.Serialize = Serialize
 
-function AddOn_Chomp.Serialize(object)
+function Chomp.Serialize(object)
 	local objectType = type(object)
 	if not rawget(Serialize, type(object)) then
-		error("AddOn_Chomp.Serialize(): object: expected serializable type, got " .. objectType, 2)
+		error("Chomp.Serialize(): object: expected serializable type, got " .. objectType, 2)
 	end
 	local success, serialized = pcall(Serialize[objectType], object)
 	if not success then
-		error("AddOn_Chomp.Serialize(): object: could not be serialized due to finding unserializable type", 2)
+		error("Chomp.Serialize(): object: could not be serialized due to finding unserializable type", 2)
 	end
 	return serialized
 end
@@ -262,19 +262,19 @@ local EMPTY_ENV = setmetatable({}, {
 	__metatable = false,
 })
 
-function AddOn_Chomp.Deserialize(text)
+function Chomp.Deserialize(text)
 	if type(text) ~= "string" then
-		error("AddOn_Chomp.Deserialize(): text: expected string, got " .. type(text), 2)
+		error("Chomp.Deserialize(): text: expected string, got " .. type(text), 2)
 	end
 
 	local isSafe, reason = IsStringLoadSafe(text)
 	if not isSafe then
-		error("AddOn_Chomp.Deserialize(): text: " .. reason, 2)
+		error("Chomp.Deserialize(): text: " .. reason, 2)
 	end
 
 	local func, loadError = loadstring(("return %s"):format(text))
 	if not func then
-		error("AddOn_Chomp.Deserialize(): text: could not be deserialized: " .. tostring(loadError), 2)
+		error("Chomp.Deserialize(): text: could not be deserialized: " .. tostring(loadError), 2)
 	end
 
 	setfenv(func, EMPTY_ENV)
@@ -283,19 +283,19 @@ function AddOn_Chomp.Deserialize(text)
 	local retType = type(ret)
 
 	if not retSuccess then
-		error("AddOn_Chomp.Deserialize(): text: error while reading data", 2)
+		error("Chomp.Deserialize(): text: error while reading data", 2)
 	elseif not Serialize[retType] then
-		error("AddOn_Chomp.Deserialize(): text: deserialized to invalid type: " .. type(ret), 2)
+		error("Chomp.Deserialize(): text: deserialized to invalid type: " .. type(ret), 2)
 	elseif retType == "table" and text:find("function", nil, true) and not IsTableSafe(ret) then
-		error("AddOn_Chomp.Deserialize(): text: deserialized table included forbidden type", 2)
+		error("Chomp.Deserialize(): text: deserialized table included forbidden type", 2)
 	end
 
 	return ret
 end
 
-function AddOn_Chomp.CheckLoggedContents(text)
+function Chomp.CheckLoggedContents(text)
 	if type(text) ~= "string" then
-		error("AddOn_Chomp.CheckLoggedContents(): text: expected string, got " .. type(text), 2)
+		error("Chomp.CheckLoggedContents(): text: expected string, got " .. type(text), 2)
 	end
 	if text:find("[%z\001-\009\011-\031\127]") then
 		return false, "ASCII_CONTROL"
@@ -379,14 +379,14 @@ function Internal.EncodeQuotedPrintable(text, restrictBinary, codecVersion)
 	return text
 end
 
-function AddOn_Chomp.EncodeQuotedPrintable(text, codecVersion)
+function Chomp.EncodeQuotedPrintable(text, codecVersion)
 	if type(text) ~= "string" then
-		error("AddOn_Chomp.EncodeQuotedPrintable(): text: expected string, got " .. type(text), 2)
+		error("Chomp.EncodeQuotedPrintable(): text: expected string, got " .. type(text), 2)
 	elseif codecVersion ~= nil then
 		if type(codecVersion) ~= "number" then
-			error("AddOn_Chomp.EncodeQuotedPrintable(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
+			error("Chomp.EncodeQuotedPrintable(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
 		elseif not CodecsByVersion[codecVersion] then
-			error("AddOn_Chomp.EncodeQuotedPrintable(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
+			error("Chomp.EncodeQuotedPrintable(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
 		end
 	end
 
@@ -454,14 +454,14 @@ function Internal.DecodeQuotedPrintable(text, restrictBinary, codecVersion)
 	return decodedText
 end
 
-function AddOn_Chomp.DecodeQuotedPrintable(text, codecVersion)
+function Chomp.DecodeQuotedPrintable(text, codecVersion)
 	if type(text) ~= "string" then
-		error("AddOn_Chomp.DecodeQuotedPrintable(): text: expected string, got " .. type(text), 2)
+		error("Chomp.DecodeQuotedPrintable(): text: expected string, got " .. type(text), 2)
 	elseif codecVersion ~= nil then
 		if type(codecVersion) ~= "number" then
-			error("AddOn_Chomp.DecodeQuotedPrintable(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
+			error("Chomp.DecodeQuotedPrintable(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
 		elseif not CodecsByVersion[codecVersion] then
-			error("AddOn_Chomp.DecodeQuotedPrintable(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
+			error("Chomp.DecodeQuotedPrintable(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
 		end
 	end
 
@@ -471,20 +471,20 @@ function AddOn_Chomp.DecodeQuotedPrintable(text, codecVersion)
 	return decodedText
 end
 
-function AddOn_Chomp.SafeSubString(text, first, last, textLen, codecVersion)
+function Chomp.SafeSubString(text, first, last, textLen, codecVersion)
 	if type(text) ~= "string" then
-		error("AddOn_Chomp.SafeSubString(): text: expected string, got " .. type(text), 2)
+		error("Chomp.SafeSubString(): text: expected string, got " .. type(text), 2)
 	elseif type(first) ~= "number" then
-		error("AddOn_Chomp.SafeSubString(): first: expected number, got " .. type(first), 2)
+		error("Chomp.SafeSubString(): first: expected number, got " .. type(first), 2)
 	elseif type(last) ~= "number" then
-		error("AddOn_Chomp.SafeSubString(): last: expected number, got " .. type(last), 2)
+		error("Chomp.SafeSubString(): last: expected number, got " .. type(last), 2)
 	elseif textLen and type(textLen) ~= "number" then
-		error("AddOn_Chomp.SafeSubString(): textLen: expected number or nil, got " .. type(textLen), 2)
+		error("Chomp.SafeSubString(): textLen: expected number or nil, got " .. type(textLen), 2)
 	elseif codecVersion ~= nil then
 		if type(codecVersion) ~= "number" then
-			error("AddOn_Chomp.SafeSubstring(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
+			error("Chomp.SafeSubstring(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
 		elseif not CodecsByVersion[codecVersion] then
-			error("AddOn_Chomp.SafeSubstring(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
+			error("Chomp.SafeSubstring(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
 		end
 	end
 
@@ -495,7 +495,7 @@ function AddOn_Chomp.SafeSubString(text, first, last, textLen, codecVersion)
 		textLen = #text
 	end
 	if first > textLen then
-		error("AddOn_Chomp.SafeSubString(): first: starting index exceeds text length", 2)
+		error("Chomp.SafeSubString(): first: starting index exceeds text length", 2)
 	end
 	if textLen > last then
 		local b3, b2, b1 = text:byte(last - 2, last)
@@ -510,7 +510,7 @@ function AddOn_Chomp.SafeSubString(text, first, last, textLen, codecVersion)
 	return (text:sub(first, last - offset)), offset
 end
 
-function AddOn_Chomp.InsensitiveStringEquals(a, b)
+function Chomp.InsensitiveStringEquals(a, b)
 	if a == b then
 		return true
 	end

--- a/StringManip.lua
+++ b/StringManip.lua
@@ -101,9 +101,9 @@ local FULL_PLAYER_FIND = FULL_PLAYER_NAME:gsub("-", "%%%%-"):format("^.-", ".+$"
 
 function Chomp.NameMergedRealm(name, realm)
 	if type(name) ~= "string" then
-		error("Chomp.NameMergedRealm(): name: expected string, got " .. type(name), 2)
+		error("Chomp.NameMergedRealm: name: expected string, got " .. type(name), 2)
 	elseif name == "" then
-		error("Chomp.NameMergedRealm(): name: expected non-empty string", 2)
+		error("Chomp.NameMergedRealm: name: expected non-empty string", 2)
 	elseif not realm or realm == "" then
 		-- Normally you'd just return the full input name without reformatting,
 		-- but Blizzard has started returning an occasional "Name-Realm Name"
@@ -116,7 +116,7 @@ function Chomp.NameMergedRealm(name, realm)
 			realm = GetRealmName()
 		end
 	elseif name:find(FULL_PLAYER_FIND) then
-		error("Chomp.NameMergedRealm(): name already has a realm name, but realm name also provided")
+		error("Chomp.NameMergedRealm: name already has a realm name, but realm name also provided")
 	end
 	return FULL_PLAYER_NAME:format(name, (realm:gsub("[%s%-]", "")))
 end
@@ -195,11 +195,11 @@ Internal.Serialize = Serialize
 function Chomp.Serialize(object)
 	local objectType = type(object)
 	if not rawget(Serialize, type(object)) then
-		error("Chomp.Serialize(): object: expected serializable type, got " .. objectType, 2)
+		error("Chomp.Serialize: object: expected serializable type, got " .. objectType, 2)
 	end
 	local success, serialized = pcall(Serialize[objectType], object)
 	if not success then
-		error("Chomp.Serialize(): object: could not be serialized due to finding unserializable type", 2)
+		error("Chomp.Serialize: object: could not be serialized due to finding unserializable type", 2)
 	end
 	return serialized
 end
@@ -264,17 +264,17 @@ local EMPTY_ENV = setmetatable({}, {
 
 function Chomp.Deserialize(text)
 	if type(text) ~= "string" then
-		error("Chomp.Deserialize(): text: expected string, got " .. type(text), 2)
+		error("Chomp.Deserialize: text: expected string, got " .. type(text), 2)
 	end
 
 	local isSafe, reason = IsStringLoadSafe(text)
 	if not isSafe then
-		error("Chomp.Deserialize(): text: " .. reason, 2)
+		error("Chomp.Deserialize: text: " .. reason, 2)
 	end
 
 	local func, loadError = loadstring(("return %s"):format(text))
 	if not func then
-		error("Chomp.Deserialize(): text: could not be deserialized: " .. tostring(loadError), 2)
+		error("Chomp.Deserialize: text: could not be deserialized: " .. tostring(loadError), 2)
 	end
 
 	setfenv(func, EMPTY_ENV)
@@ -283,11 +283,11 @@ function Chomp.Deserialize(text)
 	local retType = type(ret)
 
 	if not retSuccess then
-		error("Chomp.Deserialize(): text: error while reading data", 2)
+		error("Chomp.Deserialize: text: error while reading data", 2)
 	elseif not Serialize[retType] then
-		error("Chomp.Deserialize(): text: deserialized to invalid type: " .. type(ret), 2)
+		error("Chomp.Deserialize: text: deserialized to invalid type: " .. type(ret), 2)
 	elseif retType == "table" and text:find("function", nil, true) and not IsTableSafe(ret) then
-		error("Chomp.Deserialize(): text: deserialized table included forbidden type", 2)
+		error("Chomp.Deserialize: text: deserialized table included forbidden type", 2)
 	end
 
 	return ret
@@ -295,7 +295,7 @@ end
 
 function Chomp.CheckLoggedContents(text)
 	if type(text) ~= "string" then
-		error("Chomp.CheckLoggedContents(): text: expected string, got " .. type(text), 2)
+		error("Chomp.CheckLoggedContents: text: expected string, got " .. type(text), 2)
 	end
 	if text:find("[%z\001-\009\011-\031\127]") then
 		return false, "ASCII_CONTROL"
@@ -381,12 +381,12 @@ end
 
 function Chomp.EncodeQuotedPrintable(text, codecVersion)
 	if type(text) ~= "string" then
-		error("Chomp.EncodeQuotedPrintable(): text: expected string, got " .. type(text), 2)
+		error("Chomp.EncodeQuotedPrintable: text: expected string, got " .. type(text), 2)
 	elseif codecVersion ~= nil then
 		if type(codecVersion) ~= "number" then
-			error("Chomp.EncodeQuotedPrintable(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
+			error("Chomp.EncodeQuotedPrintable: codecVersion: expected number or nil, got " .. type(codecVersion), 2)
 		elseif not CodecsByVersion[codecVersion] then
-			error("Chomp.EncodeQuotedPrintable(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
+			error("Chomp.EncodeQuotedPrintable: codecVersion: unsupported codec version " .. type(codecVersion), 2)
 		end
 	end
 
@@ -456,12 +456,12 @@ end
 
 function Chomp.DecodeQuotedPrintable(text, codecVersion)
 	if type(text) ~= "string" then
-		error("Chomp.DecodeQuotedPrintable(): text: expected string, got " .. type(text), 2)
+		error("Chomp.DecodeQuotedPrintable: text: expected string, got " .. type(text), 2)
 	elseif codecVersion ~= nil then
 		if type(codecVersion) ~= "number" then
-			error("Chomp.DecodeQuotedPrintable(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
+			error("Chomp.DecodeQuotedPrintable: codecVersion: expected number or nil, got " .. type(codecVersion), 2)
 		elseif not CodecsByVersion[codecVersion] then
-			error("Chomp.DecodeQuotedPrintable(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
+			error("Chomp.DecodeQuotedPrintable: codecVersion: unsupported codec version " .. type(codecVersion), 2)
 		end
 	end
 
@@ -473,18 +473,18 @@ end
 
 function Chomp.SafeSubString(text, first, last, textLen, codecVersion)
 	if type(text) ~= "string" then
-		error("Chomp.SafeSubString(): text: expected string, got " .. type(text), 2)
+		error("Chomp.SafeSubString: text: expected string, got " .. type(text), 2)
 	elseif type(first) ~= "number" then
-		error("Chomp.SafeSubString(): first: expected number, got " .. type(first), 2)
+		error("Chomp.SafeSubString: first: expected number, got " .. type(first), 2)
 	elseif type(last) ~= "number" then
-		error("Chomp.SafeSubString(): last: expected number, got " .. type(last), 2)
+		error("Chomp.SafeSubString: last: expected number, got " .. type(last), 2)
 	elseif textLen and type(textLen) ~= "number" then
-		error("Chomp.SafeSubString(): textLen: expected number or nil, got " .. type(textLen), 2)
+		error("Chomp.SafeSubString: textLen: expected number or nil, got " .. type(textLen), 2)
 	elseif codecVersion ~= nil then
 		if type(codecVersion) ~= "number" then
-			error("Chomp.SafeSubstring(): codecVersion: expected number or nil, got " .. type(codecVersion), 2)
+			error("Chomp.SafeSubstring: codecVersion: expected number or nil, got " .. type(codecVersion), 2)
 		elseif not CodecsByVersion[codecVersion] then
-			error("Chomp.SafeSubstring(): codecVersion: unsupported codec version " .. type(codecVersion), 2)
+			error("Chomp.SafeSubstring: codecVersion: unsupported codec version " .. type(codecVersion), 2)
 		end
 	end
 
@@ -495,7 +495,7 @@ function Chomp.SafeSubString(text, first, last, textLen, codecVersion)
 		textLen = #text
 	end
 	if first > textLen then
-		error("Chomp.SafeSubString(): first: starting index exceeds text length", 2)
+		error("Chomp.SafeSubString: first: starting index exceeds text length", 2)
 	end
 	if textLen > last then
 		local b3, b2, b1 = text:byte(last - 2, last)

--- a/StringManip.lua
+++ b/StringManip.lua
@@ -14,11 +14,12 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-if not __chomp_internal or not __chomp_internal.LOADING then
+local Chomp = LibStub:GetLibrary("Chomp", true)
+local Internal = Chomp and Chomp.Internal or nil
+
+if not Chomp or not Internal or not Internal.LOADING then
 	return
 end
-
-local Internal = __chomp_internal
 
 -- Version 1, using "`" as the escape sequence character. Deprecated and will be removed eventually.
 local CodecV1 = {}


### PR DESCRIPTION
This makes Chomp a Good Citizen:tm: and stops it from reinventing the wheel of library versioning for no heckin' good reason.

Chomp now registers itself via LibStub with the major "Chomp" and the same incrementing (minor) version number it always has. The internal table is stored on our library instance as the "Internal" subkey instead of as the "__chomp_internal" global, though for compatibility with addons that might pull in older versions of the library the old internal global is still exported until the PLAYER_LOGIN event has fired.

This change is fully backwards compatible as far as the public API is concerned; The AddOn_Chomp global is still defined and just points to the same library table registered with LibStub. For addons that have captured the old AddOn_Chomp as an upvalue this _shouldn't_ cause an issue as there's no state on the old table that's required by the library, since the whole public API avoids use of "self".

Note that the internal table is accessible after PLAYER_LOGIN has fired via "Internal" key of the API table; this is 
intentional to assist with debugging, and because not doing so just leads to people doing dumb stuff to get access to it anyway.

No work has been done to make the library upgradable after PLAYER_LOGIN has fired; this would be a substantial task and likely can't be done until the older versions are no longer in circulation.