### PR TITLE
Add IsAddonPrefixRegistered function to API

### DIFF
--- a/Public.lua
+++ b/Public.lua
@@ -411,6 +411,10 @@ function AddOn_Chomp.RegisterAddonPrefix(prefix, callback, prefixSettings)
 	end
 end
 
+function AddOn_Chomp.IsAddonPrefixRegistered(prefix)
+	return Internal.Prefixes[prefix] ~= nil
+end
+
 local nextSessionID = math.random(0, 4095)
 local function SplitAndSend(sendFunc, maxSize, bitField, prefix, text, ...)
 	local textLen = #text


### PR DESCRIPTION
Useful for checking if something has been registered with Chomp or not, since currently RegisterAddonPrefix will error upon a second attempt to register a prefix.