### PR TITLE
Prevent emission of duplicate error events

### DIFF
--- a/Internal.lua
+++ b/Internal.lua
@@ -397,7 +397,9 @@ end
 -- Hooks don't trigger if the hooked function errors, so there's no need to
 -- check parameters, if those parameters cause errors (which most don't now).
 
-local function MessageEventFilter_SYSTEM (self, event, text)
+local lastFilteredLineID = nil
+
+local function MessageEventFilter_SYSTEM (self, event, text, ...)
 	local name = text:match(ERR_CHAT_PLAYER_NOT_FOUND_S:format("(.+)"))
 	if not name then
 		return false
@@ -405,7 +407,14 @@ local function MessageEventFilter_SYSTEM (self, event, text)
 		Internal.Filter[name] = nil
 		return false
 	end
-	Internal:TriggerEvent("OnError", name)
+
+	local lineID = select(10, ...)
+
+	if lineID ~= lastFilteredLineID then
+		Internal:TriggerEvent("OnError", name)
+		lastFilteredLineID = lineID
+	end
+
 	return true
 end
 


### PR DESCRIPTION
Chat filters are executed once per chat frame that is registered for a given event; if a message is sent through Chomp to an offline player the SYSTEM message filter can trigger the OnError callback multiple times if there exists multiple chat frames all registered for that message type.

This changeset makes it so that the OnError callback is only executed once per message by deduplicating with the unique line ID.