### PR TITLE
Remove support for older serialization codec

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -49,6 +49,7 @@ read_globals = {
 	"C_Timer.NewTicker",
 	"CallErrorHandler",
 	"ChatFrame_AddMessageEventFilter",
+	"CopyValuesAsKeys",
 	"CreateFrame",
 	"CreateFromMixins",
 	"DoublyLinkedListMixin",

--- a/Internal.lua
+++ b/Internal.lua
@@ -138,10 +138,9 @@ local function HandleMessageIn(prefix, text, channel, sender, target, zoneChanne
 		text = userText
 	end
 
-	local codecVersion = Internal:GetCodecVersionFromBitfield(bitField)
 	local method = channel:match("%:(%u+)$")
 	if method == "BATTLENET" or method == "LOGGED" then
-		text = Internal.DecodeQuotedPrintable(text, method == "LOGGED", codecVersion)
+		text = Internal.DecodeQuotedPrintable(text, method == "LOGGED")
 	end
 
 	if bit.bor(bitField, Internal.KNOWN_BITS) ~= Internal.KNOWN_BITS or bit.band(bitField, Internal.BITS.DEPRECATE) == Internal.BITS.DEPRECATE then
@@ -268,10 +267,6 @@ local function ParseBattleNetMessage(prefix, text, kind, bnetIDGameAccount)
 	end
 
 	return prefix, text, ("%s:BATTLENET"):format(kind), name, Chomp.NameMergedRealm(UnitName("player")), 0, 0, "", 0
-end
-
-function Internal:GetCodecVersionFromBitfield(bitField)
-	return (bit.band(bitField, Internal.BITS.CODECV2) ~= 0) and 2 or 1
 end
 
 --[[

--- a/Internal.lua
+++ b/Internal.lua
@@ -153,7 +153,8 @@ local function HandleMessageIn(prefix, text, channel, sender, target, zoneChanne
 	end
 
 	local hasVersion16 = bit.band(bitField, Internal.BITS.VERSION16) ~= 0
-	if not hasVersion16 then
+	local hasCodecV2 = bit.band(bitField, Internal.BITS.CODECV2) ~= 0
+	if not hasVersion16 or not hasCodecV2 then
 		-- Sender is using a version of Chomp that's far too old. Ignore
 		-- as we probably can't communicate with them anyway.
 		return


### PR DESCRIPTION
This removes support for the older serialization codec which was replaced a while ago due to efficency concerns over its choice of escape character.

The support for the newer codec was added in v16 - released about three years ago. Compatibility at the time with pre-v16 peers was maintained through abusing a typo in the addon that allowed us to set a 'VERSION16' bit on messages that was ignored by older clients. If a v16+ client then received this bit, it would mark the peer as supporting the newer codec and use it for future transmissions indicated through a new 'CODECV2' bit.

About two years ago in v20, we made a change to drop pre-v16 support by unilaterally broadcasting the 'CODECV2' bit, and to ignore all messages from ancient clients.

Now we're safely in a position where the old codec can be entirely removed. This commit makes no changes to the wire protocol, nor does it alter any bits - it strictly removes a rather large dead code path that is entirely unreachable.