### PR TITLE
Make reduced comms throughput only affect Classic

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -82,5 +82,5 @@ read_globals = {
 	"UNKNOWNOBJECT",
 	"wipe",
 	"WOW_PROJECT_ID",
-	"WOW_PROJECT_RETAIL",
+	"WOW_PROJECT_MAINLINE",
 }

--- a/Internal.lua
+++ b/Internal.lua
@@ -14,7 +14,7 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-local VERSION = 19
+local VERSION = 20
 
 if IsLoggedIn() then
 	error(("Chomp Message Library (embedded: %s) cannot be loaded after login."):format((...)))

--- a/Internal.lua
+++ b/Internal.lua
@@ -42,7 +42,7 @@ Internal.callbacks = LibStub:GetLibrary("CallbackHandler-1.0"):New(Internal)
 -- Lower rates on non-Retail clients due to aggressive throttling.
 local BURST, BPS
 
-if WOW_PROJECT_ID == WOW_PROJECT_RETAIL then
+if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
 	BURST, BPS = 8192, 2048
 else
 	BURST, BPS = 4000, 800


### PR DESCRIPTION
We were testing a constant that's never defined, thus actually limiting comms bandwidth on all clients to the levels 
 supported by Classic.

#katwasright