### PR TITLE
Use v2 serialization codec by default

### DIFF
--- a/Internal.lua
+++ b/Internal.lua
@@ -153,15 +153,15 @@ local function HandleMessageIn(prefix, text, channel, sender, target, zoneChanne
 		return
 	end
 
-	if not prefixData[sender] then
-		prefixData[sender] = {}
+	local hasVersion16 = bit.band(bitField, Internal.BITS.VERSION16) ~= 0
+	if not hasVersion16 then
+		-- Sender is using a version of Chomp that's far too old. Ignore
+		-- as we probably can't communicate with them anyway.
+		return;
 	end
 
-	local hasVersion16 = bit.band(bitField, Internal.BITS.VERSION16) ~= 0
-	if hasVersion16 then
-		prefixData[sender].supportsCodecV2 = true
-	else
-		prefixData[sender].supportsCodecV2 = false
+	if not prefixData[sender] then
+		prefixData[sender] = {}
 	end
 
 	local isBroadcast = bit.band(bitField, Internal.BITS.BROADCAST) == Internal.BITS.BROADCAST
@@ -268,13 +268,6 @@ local function ParseBattleNetMessage(prefix, text, kind, bnetIDGameAccount)
 	end
 
 	return prefix, text, ("%s:BATTLENET"):format(kind), name, Chomp.NameMergedRealm(UnitName("player")), 0, 0, "", 0
-end
-
-function Internal:TargetSupportsCodecV2(prefix, target)
-	local prefixData = self.Prefixes[prefix]
-	local targetData = prefixData and prefixData[target] or nil
-
-	return targetData and targetData.supportsCodecV2 or false
 end
 
 function Internal:GetCodecVersionFromBitfield(bitField)

--- a/Public.lua
+++ b/Public.lua
@@ -496,7 +496,12 @@ function Chomp.SmartAddonMessage(prefix, data, kind, target, messageOptions)
 	end
 
 	local bitField = 0x000
-	bitField = bit.bor(bitField, Internal.BITS.VERSION16)
+	local codecVersion = 2
+
+	-- v20+: Always set the CODECV2 bit. All clients on the network at this
+	--       point should support it. Setting this bit unconditionally will
+	--       eventually allow us to deprecate receipt of v1 codec data.
+	bitField = bit.bor(bitField, Internal.BITS.VERSION16, Internal.BITS.CODECV2)
 
 	if messageOptions.serialize then
 		bitField = bit.bor(bitField, Internal.BITS.SERIALIZE)
@@ -511,15 +516,6 @@ function Chomp.SmartAddonMessage(prefix, data, kind, target, messageOptions)
 
 	if kind == "WHISPER" then
 		target = Chomp.NameMergedRealm(target)
-	end
-
-	local codecVersion
-
-	if Internal:TargetSupportsCodecV2(prefix, target) then
-		codecVersion = 2
-		bitField = bit.bor(bitField, Internal.BITS.CODECV2)
-	else
-		codecVersion = 1
 	end
 
 	local queue = ("%s%s%s"):format(prefix, kind, tostring(target) or "")


### PR DESCRIPTION
This removes the ability for us to communicate with pre-v16 versions of Chomp by enforcing that all serialization goes through the new codec version. This will, in turn, allow us to deprecate and remove the old v1 codec later on down the line when nothing on the network should be sending us v1 codec data (#47).

Unfortunately that can't be done now due to the nature of codec autonegotiation starting off with v1 and upgrading to v2 based upon received bitflags.