### PR TITLE
Improve handling of realm names in message filter

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -71,6 +71,8 @@ read_globals = {
 	"PlayerLocationMixin",
 	"SendChatMessage",
 	"strcmputf8i",
+	"string.join",
+	"string.split",
 	"tInvert",
 	"UnitFactionGroup",
 	"UnitFullName",

--- a/Internal.lua
+++ b/Internal.lua
@@ -157,7 +157,7 @@ local function HandleMessageIn(prefix, text, channel, sender, target, zoneChanne
 	if not hasVersion16 then
 		-- Sender is using a version of Chomp that's far too old. Ignore
 		-- as we probably can't communicate with them anyway.
-		return;
+		return
 	end
 
 	if not prefixData[sender] then
@@ -390,7 +390,7 @@ end
 -- Hooks don't trigger if the hooked function errors, so there's no need to
 -- check parameters, if those parameters cause errors (which most don't now).
 
-local FILTER_PATTERN = ERR_CHAT_PLAYER_NOT_FOUND_S:format("(.+)");
+local FILTER_PATTERN = ERR_CHAT_PLAYER_NOT_FOUND_S:format("(.+)")
 local lastFilteredLineID = nil
 
 if not Internal.MessageFilterKeyCache then
@@ -398,8 +398,8 @@ if not Internal.MessageFilterKeyCache then
 end
 
 local function GenerateMessageFilterKey(target)
-	local filterKey = target;
-	local targetName, targetRealm = string.split("-", filterKey, 2);
+	local filterKey = target
+	local targetName, targetRealm = string.split("-", filterKey, 2)
 
 	-- Given a WHISPER message submitted to the API with the target set to
 	-- "bob-azjol nerub", the resulting error message sent by the server will
@@ -407,7 +407,7 @@ local function GenerateMessageFilterKey(target)
 	-- normalizing the realm name.
 
 	if targetRealm then
-		filterKey = string.join("-", targetName, (string.gsub(targetRealm, "[%s-]", "")));
+		filterKey = string.join("-", targetName, (string.gsub(targetRealm, "[%s-]", "")))
 	end
 
 	if string.utf8lower then
@@ -416,7 +416,7 @@ local function GenerateMessageFilterKey(target)
 		filterKey = string.lower(filterKey)
 	end
 
-	return filterKey;
+	return filterKey
 end
 
 setmetatable(Internal.MessageFilterKeyCache, {


### PR DESCRIPTION
When a WHISPER message is sent to a player with a fully qualified name that includes the realm, the error message sent back by the server won't necessarily be 1:1 with the string submitted as the "target" parameter of the API.

There's two cases where this happens:

  1. The realm name wasn't in normalized form ("Azjol Nerub")
  2. The realm name wasn't case-correct ("azjolnerub")

In both of the above cases the error message given by the server would case-correct and normalize the realm name in the response, leading to cases where the key in our target table doesn't align with that of the fully qualified player name received in the error message, resulting in the offline player message filter potentially allowing errors through.

This changeset attempts to paper over the issue by normalizing target names client-side; we'll transform the target name to a lowercase format and normalize the realm segment if present and store that as the key for our filter. The same key is then generated and looked up on receipt of an error, which should result in more correct handling if the server applied any such transforms itself.