### PR TITLE
Only use character names for error filtering

### DIFF
--- a/Internal.lua
+++ b/Internal.lua
@@ -447,7 +447,6 @@ end
 local function HookSendAddonMessage(prefix, text, kind, target)
 	if kind == "WHISPER" and target then
 		local filterKey = Internal.MessageFilterKeyCache[target]
-		print("Send with fk", filterKey)
 		Internal.Filter[filterKey] = GetTime() + (select(3, GetNetStats()) * 0.001) + 5.000
 	end
 	if Internal.isSending then return end

--- a/Internal.lua
+++ b/Internal.lua
@@ -398,17 +398,11 @@ if not Internal.MessageFilterKeyCache then
 end
 
 local function GenerateMessageFilterKey(target)
-	local filterKey = target
-	local targetName, targetRealm = string.split("-", filterKey, 2)
+	-- Due to systemic issues across ourselves, LibMSP, TRP, etc. this
+	-- filter has been hacked to only use the character name of the player
+	-- and to discard the realm.
 
-	-- Given a WHISPER message submitted to the API with the target set to
-	-- "bob-azjol nerub", the resulting error message sent by the server will
-	-- name the target as "bob-AzjolNerub" - both case correcting and
-	-- normalizing the realm name.
-
-	if targetRealm then
-		filterKey = string.join("-", targetName, (string.gsub(targetRealm, "[%s-]", "")))
-	end
+	local filterKey = string.split("-", target, 2)
 
 	if string.utf8lower then
 		filterKey = string.utf8lower(filterKey)
@@ -453,6 +447,7 @@ end
 local function HookSendAddonMessage(prefix, text, kind, target)
 	if kind == "WHISPER" and target then
 		local filterKey = Internal.MessageFilterKeyCache[target]
+		print("Send with fk", filterKey)
 		Internal.Filter[filterKey] = GetTime() + (select(3, GetNetStats()) * 0.001) + 5.000
 	end
 	if Internal.isSending then return end

--- a/Internal.lua
+++ b/Internal.lua
@@ -14,7 +14,7 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-local VERSION = 23
+local VERSION = 24
 
 if IsLoggedIn() then
 	error(("Chomp Message Library (embedded: %s) cannot be loaded after login."):format((...)))


### PR DESCRIPTION
Chomp (and a lot of other RP-related stuff) incorrectly use the localized realm name in a lot of stuff relating to comms rather than normalized realm names.

For realms in the latin alphabet this works fine largely as we've been performing rudimentary normalization, however for realms in non-latin alphabets this approach for normalization doesn't work.

As changing to normalized realm names would be a wide-ranging and broadly painful change, the message filter for offline player messages will now only use the lowercased character name as the filter key.

This should be fine as it's not likely that someone will be sending messages to two identically named characters on different realms at once.