### PR TITLE
Filter cross-region characters from Battle.net

### DIFF
--- a/Internal.lua
+++ b/Internal.lua
@@ -573,6 +573,8 @@ local function CanExchangeWithGameAccount(account)
 		return false  -- Friend isn't even online.
 	elseif account.clientProgram ~= BNET_CLIENT_WOW then
 		return false  -- Friend isn't playing WoW. Imagine.
+	elseif not account.isInCurrentRegion then
+		return false
 	end
 
 	local characterName = account.characterName


### PR DESCRIPTION
Currently, when determining the names and realms of valid WoW characters on a players' battle.net friends list we don't take into consideration the cross-region functionality that was added in Shadowlands, and as such think that we can send game data cross-region.

This is *probably* something that is completely impossible to do, so it makes sense to not consider such characters as valid. This should mean that we no longer get confused if a player has in their battle.net friends list two players in different regions that magically have the exact same character and realm names.