### PR TITLE
Handle throttle return codes from send APIs

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -46,6 +46,7 @@ read_globals = {
 	"C_ReportSystem.CanReportPlayer",
 	"C_ReportSystem.OpenReportPlayerDialog",
 	"C_Timer.After",
+	"C_Timer.NewTicker",
 	"CallErrorHandler",
 	"ChatFrame_AddMessageEventFilter",
 	"CreateFrame",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -51,6 +51,7 @@ read_globals = {
 	"CreateFrame",
 	"CreateFromMixins",
 	"DoublyLinkedListMixin",
+	"Enum.SendAddonMessageResult",
 	"ERR_CHAT_PLAYER_NOT_FOUND_S",
 	"FULL_PLAYER_NAME",
 	"GetAutoCompleteRealms",

--- a/Internal.lua
+++ b/Internal.lua
@@ -301,7 +301,7 @@ local function MapToSendAddonMessageResult(result)
 	return result
 end
 
-local function IsRecoverableDeliveryError(result)
+local function ShouldRetryTransmission(result)
 	if result == SendAddonMessageResult.AddonMessageThrottle then
 		return true
 	elseif result == SendAddonMessageResult.ChannelThrottle then
@@ -337,7 +337,7 @@ function Internal:RunQueue()
 				sendResult = MapToSendAddonMessageResult(select(-1, message.f(unpack(message, 1, 4))))
 				self.isSending = false
 			end
-			if IsRecoverableDeliveryError(sendResult) then
+			if ShouldRetryTransmission(sendResult) then
 				-- Requeue the message, but don't requeue the queue.
 				queue:PushFront(message)
 				priority.bytes = priority.bytes + message.length

--- a/Internal.lua
+++ b/Internal.lua
@@ -322,8 +322,7 @@ function Internal:RunQueue()
 			active[#active + 1] = self[priority]
 		end
 	end
-	local remaining = #active
-	local bytes = self.bytes / remaining
+	local bytes = self.bytes / #active
 	self.bytes = 0
 	for i, priority in ipairs(active) do
 		priority.bytes = priority.bytes + bytes
@@ -355,7 +354,6 @@ function Internal:RunQueue()
 			end
 		end
 		if not priority.front then
-			remaining = remaining - 1
 			self.bytes = self.bytes + priority.bytes
 			priority.bytes = 0
 		end
@@ -365,6 +363,16 @@ function Internal:RunQueue()
 		local queue = blockedQueueInfo.queue
 		priority:PushBack(queue)
 	end
+end
+
+function Internal:HasQueuedData()
+	for _, priority in ipairs(PRIORITIES) do
+		if self[priority].front then
+			return true;
+		end
+	end
+
+	return false;
 end
 
 function Internal:UpdateBytes()

--- a/Internal.lua
+++ b/Internal.lua
@@ -291,7 +291,7 @@ local SendAddonMessageResult = Mixin({
     GeneralError = 9,  -- Reporting for duty, sir!
 }, Enum.SendAddonMessageResult or {})
 
-local function MapToSendAddonMessageResult(result)
+function Internal:MapToSendAddonMessageResult(result)
 	if result == true then
 		result = SendAddonMessageResult.Success
 	elseif result == false then
@@ -301,7 +301,7 @@ local function MapToSendAddonMessageResult(result)
 	return result
 end
 
-local function ShouldRetryTransmission(result)
+function Internal:IsRetryMessageResult(result)
 	if result == SendAddonMessageResult.AddonMessageThrottle then
 		return true
 	elseif result == SendAddonMessageResult.ChannelThrottle then
@@ -333,10 +333,10 @@ function Internal:RunQueue()
 			if (message.kind ~= "RAID" and message.kind ~= "PARTY" or IsInGroup(LE_PARTY_CATEGORY_HOME)) and (message.kind ~= "INSTANCE_CHAT" or IsInGroup(LE_PARTY_CATEGORY_INSTANCE)) then
 				priority.bytes = priority.bytes - message.length
 				self.isSending = true
-				sendResult = MapToSendAddonMessageResult(select(-1, message.f(unpack(message, 1, 4))))
+				sendResult = self:MapToSendAddonMessageResult(select(-1, message.f(unpack(message, 1, 4))))
 				self.isSending = false
 			end
-			if ShouldRetryTransmission(sendResult) then
+			if self:IsRetryMessageResult(sendResult) then
 				-- Requeue the message, but don't requeue the queue.
 				queue:PushFront(message)
 				priority.bytes = priority.bytes + message.length

--- a/Internal.lua
+++ b/Internal.lua
@@ -359,8 +359,7 @@ function Internal:RunQueue()
 		end
 	end
 	for _, blockedQueueInfo in ipairs(blockedQueues) do
-		local priority = blockedQueueInfo.priority
-		local queue = blockedQueueInfo.queue
+		local priority, queue = unpack(blockedQueueInfo)
 		priority:PushBack(queue)
 	end
 end

--- a/Internal.lua
+++ b/Internal.lua
@@ -322,7 +322,7 @@ function Internal:RunQueue()
 			active[#active + 1] = self[priority]
 		end
 	end
-	local bytes = self.bytes / #active
+	local bytes = (#active > 0 and self.bytes / #active or 0)
 	self.bytes = 0
 	for i, priority in ipairs(active) do
 		priority.bytes = priority.bytes + bytes

--- a/Internal.lua
+++ b/Internal.lua
@@ -333,7 +333,7 @@ function Internal:RunQueue()
 			if (message.kind ~= "RAID" and message.kind ~= "PARTY" or IsInGroup(LE_PARTY_CATEGORY_HOME)) and (message.kind ~= "INSTANCE_CHAT" or IsInGroup(LE_PARTY_CATEGORY_INSTANCE)) then
 				priority.bytes = priority.bytes - message.length
 				self.isSending = true
-				sendResult = self:MapToSendAddonMessageResult(select(-1, message.f(unpack(message, 1, 4))))
+				sendResult = self:MapToSendAddonMessageResult(select(-1, true, message.f(unpack(message, 1, 4))))
 				self.isSending = false
 			end
 			if self:IsRetryMessageResult(sendResult) then

--- a/Public.lua
+++ b/Public.lua
@@ -89,12 +89,15 @@ function Chomp.SendAddonMessage(prefix, text, kind, target, priority, queue, cal
 	if not Internal:HasQueuedData() and length <= Internal:UpdateBytes() then
 		Internal.bytes = Internal.bytes - length
 		Internal.isSending = true
-		C_ChatInfo.SendAddonMessage(prefix, text, kind, target)
+		local sendResult = select(-1, C_ChatInfo.SendAddonMessage(prefix, text, kind, target))
+		sendResult = Internal:MapToSendAddonMessageResult(sendResult)
 		Internal.isSending = false
-		if callback then
-			xpcall(callback, CallErrorHandler, callbackArg, true)
+		if not Internal:IsRetryMessageResult(sendResult) then
+			if callback then
+				xpcall(callback, CallErrorHandler, callbackArg, true)
+			end
+			return
 		end
-		return
 	end
 
 	local message = {
@@ -163,12 +166,15 @@ function Chomp.SendAddonMessageLogged(prefix, text, kind, target, priority, queu
 	if not Internal:HasQueuedData() and length <= Internal:UpdateBytes() then
 		Internal.bytes = Internal.bytes - length
 		Internal.isSending = true
-		C_ChatInfo.SendAddonMessageLogged(prefix, text, kind, target)
+		local sendResult = select(-1, C_ChatInfo.SendAddonMessageLogged(prefix, text, kind, target))
+		sendResult = Internal:MapToSendAddonMessageResult(sendResult)
 		Internal.isSending = false
-		if callback then
-			xpcall(callback, CallErrorHandler, callbackArg, true)
+		if not Internal:IsRetryMessageResult(sendResult) then
+			if callback then
+				xpcall(callback, CallErrorHandler, callbackArg, true)
+			end
+			return
 		end
-		return
 	end
 
 	local message = {

--- a/Public.lua
+++ b/Public.lua
@@ -86,7 +86,7 @@ function Chomp.SendAddonMessage(prefix, text, kind, target, priority, queue, cal
 		return
 	end
 
-	if not Internal.hasQueue and length <= Internal:UpdateBytes() then
+	if not Internal:HasQueuedData() and length <= Internal:UpdateBytes() then
 		Internal.bytes = Internal.bytes - length
 		Internal.isSending = true
 		C_ChatInfo.SendAddonMessage(prefix, text, kind, target)
@@ -160,7 +160,7 @@ function Chomp.SendAddonMessageLogged(prefix, text, kind, target, priority, queu
 		return
 	end
 
-	if not Internal.hasQueue and length <= Internal:UpdateBytes() then
+	if not Internal:HasQueuedData() and length <= Internal:UpdateBytes() then
 		Internal.bytes = Internal.bytes - length
 		Internal.isSending = true
 		C_ChatInfo.SendAddonMessageLogged(prefix, text, kind, target)
@@ -232,7 +232,7 @@ function Chomp.SendChatMessage(text, kind, language, target, priority, queue, ca
 		return
 	end
 
-	if not Internal.hasQueue and length <= Internal:UpdateBytes() then
+	if not Internal:HasQueuedData() and length <= Internal:UpdateBytes() then
 		Internal.bytes = Internal.bytes - length
 		Internal.isSending = true
 		SendChatMessage(text, kind, language, target)
@@ -287,7 +287,7 @@ function Chomp.BNSendGameData(bnetIDGameAccount, prefix, text, priority, queue, 
 
 	length = length + 18 -- 16 byte prefix, 2 byte bnetIDAccount
 
-	if not Internal.hasQueue and length <= Internal:UpdateBytes() then
+	if not Internal:HasQueuedData() and length <= Internal:UpdateBytes() then
 		Internal.bytes = Internal.bytes - length
 		Internal.isSending = true
 		BNSendGameData(bnetIDGameAccount, prefix, text)
@@ -336,7 +336,7 @@ function Chomp.BNSendWhisper(bnetIDAccount, text, priority, queue, callback, cal
 
 	length = length + 2 -- 2 byte bnetIDAccount
 
-	if not Internal.hasQueue and length <= Internal:UpdateBytes() then
+	if not Internal:HasQueuedData() and length <= Internal:UpdateBytes() then
 		Internal.bytes = Internal.bytes - length
 		Internal.isSending = true
 		BNSendWhisper(bnetIDAccount, text)


### PR DESCRIPTION
Patch 4.4.0 and 10.2.7 are "improving" SendAddonMessage and its logged cousin by making it return a bit more information on failure in the form of an enum, rather than a boolean.

This means that we can now deal with cases where the client is actively throttling comms on a specific prefix. The problem however, is that with this implementation comes a separate change that now means that *all* traffic is subject to the 10-message-slots-per-prefix system that had been applied to party and raid comms in recent patches.

This means that in cases where there's few addons actually sending data, the default tuning of Chomp's BPS and BURST values is stratospherically high and will result in messages being dropped by the API - so we need to handle the throttling.

Using the result, we'll check if the client has blocked a message due to the per-prefix or per-channel throttle, and if it is we'll requeue it and redistribute bandwidth to the remainder of the messages in the same priority.

There is a bit of gnarly logic here though - the function that sends data out only terminates its loop if there's no data left to send, or if there's not enough bytes left in the pool for us to send the remaining data with. This fights with the whole process of requeueing.

As such - when requeueing messages we put them back into the queue, redistribute the bandwidth, but we don't requeue the queue itself until we're outside of the loop, instead deferring that operation by placing it into a 'blocked queues' table.

We also now don't destroy queues before sending data, but wait until afterwards - this is required because we only want to clean up the 'priority.byName' queue reference only if a queue is in an empty and unblocked state post-send.

These changes should hopefully keep much of the logic in the successful-send and unrecoverable-failure cases the same.