### PR TITLE
Use CTL's new shiny BNSendGameData API

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -30,7 +30,6 @@ read_globals = {
 
 	-- ChatThrottleLib
 	"ChatThrottleLib.BNSendGameData",
-	"ChatThrottleLib.Enqueue",
 	"ChatThrottleLib.SendAddonMessage",
 	"ChatThrottleLib.SendAddonMessageLogged",
 	"ChatThrottleLib.SendChatMessage",
@@ -42,7 +41,6 @@ read_globals = {
 	"BNET_CLIENT_WOW",
 	"BNFeaturesEnabledAndConnected",
 	"BNGetNumFriends",
-	"BNSendGameData",
 	"C_BattleNet.GetFriendGameAccountInfo",
 	"C_BattleNet.GetFriendNumGameAccounts",
 	"C_BattleNet.GetGameAccountInfoByID",

--- a/Internal.lua
+++ b/Internal.lua
@@ -14,7 +14,7 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-local VERSION = 27
+local VERSION = 28
 
 if IsLoggedIn() then
 	error(("Chomp Message Library (embedded: %s) cannot be loaded after login."):format((...)))

--- a/Public.lua
+++ b/Public.lua
@@ -157,23 +157,8 @@ function Chomp.BNSendGameData(bnetIDGameAccount, prefix, text, priority, queue, 
 		error("Chomp.BNSendGameData: prefix: length cannot exceed 16 bytes", 2)
 	end
 
-	-- Revisit this logic later if/when CTL merges in BNSendGameData support;
-	-- until then let's poke into its guts.
-
-	if not ChatThrottleLib.Enqueue then
-		return
-	end
-
-	ChatThrottleLib:Enqueue(PRIORITY_TO_CTL[priority] or DEFAULT_PRIORITY, queue or prefix, {
-		f = BNSendGameData,
-		callbackFn = callback,
-		callbackArg = callbackArg,
-		nSize = length + (ChatThrottleLib.MSG_OVERHEAD or 40),
-		n = 3,
-		bnetIDGameAccount,
-		prefix,
-		text,
-	})
+	local kind = "WHISPER"
+	ChatThrottleLib:BNSendGameData(PRIORITY_TO_CTL[priority] or DEFAULT_PRIORITY, prefix, text, kind, bnetIDGameAccount, queue, callback, callbackArg)
 end
 
 function Chomp.IsSending()


### PR DESCRIPTION
Fixes #56. CTL version 29 or newer now has the necessary public API to support sending messages over Battle.net, so we no longer need to reach in and call the Enqueue method manually.

Let this one sit for a bit so that it doesn't get packaged too eagerly; need to wait for CTL to be updated in the SVN repo first before this can be used.