### PR TITLE
Workaround instant disconnect issue for whispers

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -55,6 +55,7 @@ read_globals = {
 	"GetAutoCompleteRealms",
 	"GetNetStats",
 	"GetRealmName",
+	"GetServerTime",
 	"GetTime",
 	"hooksecurefunc",
 	"IsLoggedIn",

--- a/Internal.lua
+++ b/Internal.lua
@@ -14,7 +14,7 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-local VERSION = 27
+local VERSION = 28
 
 if IsLoggedIn() then
 	error(("Chomp Message Library (embedded: %s) cannot be loaded after login."):format((...)))


### PR DESCRIPTION
This works around an instant disconnect bug with SendAddonMessage when sending whispers to players whose combined "character-realm" name appears to exceed this threshold, most easily noticed with players from Russian realms. See Stanzilla/WoWUIBugs#573.

As the issue is being actively fixed, hopefully we don't need this workaround for too long - so a time bomb is included to disable it after about two weeks in the event a user doesn't update.

This is only applied to "smart" messages, as those are the only ones guaranteed to be "name-realm" qualified.