### PR TITLE
Avoid Battle.net comms for grouped friends

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -64,6 +64,7 @@ read_globals = {
 	"tInvert",
 	"UnitFactionGroup",
 	"UnitFullName",
+	"UnitGUID",
 	"UnitInParty",
 	"UnitName",
 	"UNKNOWNOBJECT",

--- a/Internal.lua
+++ b/Internal.lua
@@ -14,7 +14,7 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-local VERSION = 30
+local VERSION = 31
 
 if IsLoggedIn() then
 	error(("Chomp Message Library (embedded: %s) cannot be loaded after login."):format((...)))
@@ -423,6 +423,8 @@ function Internal:GetBattleNetAccountID(targetName)
 		return nil  -- Player isn't connected to Battle.net.
 	elseif not self.bnetGameAccounts then
 		return nil  -- We have no game accounts to search.
+	elseif UnitGUID(Ambiguate(targetName, "none")) then
+		return nil  -- We think the player is in our group.
 	end
 
 	for playerName, gameAccountID in pairs(self.bnetGameAccounts) do


### PR DESCRIPTION
If the target of a whisper comm is a valid unit, then they're part of our group. We can avoid sending them comms over Battle.net and just directly whisper them, which should avoid some issues seen with BNet comms being unreliable as of late.