### PR TITLE
Don't ambiguate whisper targets

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           args: -d -z -S
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Chomp-PR-${{ github.event.number }}
           path: .release/

--- a/Public.lua
+++ b/Public.lua
@@ -56,10 +56,6 @@ function Chomp.SendAddonMessage(prefix, text, kind, target, priority, queue, cal
 		kind = kind:upper()
 	end
 
-	if target and kind == "WHISPER" then
-		target = Ambiguate(target, "none")
-	end
-
 	ChatThrottleLib:SendAddonMessage(PRIORITY_TO_CTL[priority] or DEFAULT_PRIORITY, prefix, text, kind, target, queue, callback, callbackArg)
 end
 
@@ -93,10 +89,6 @@ function Chomp.SendAddonMessageLogged(prefix, text, kind, target, priority, queu
 		kind = kind:upper()
 	end
 
-	if target and kind == "WHISPER" then
-		target = Ambiguate(target, "none")
-	end
-
 	ChatThrottleLib:SendAddonMessageLogged(PRIORITY_TO_CTL[priority] or DEFAULT_PRIORITY, prefix, text, kind, target, queue, callback, callbackArg)
 end
 
@@ -126,10 +118,6 @@ function Chomp.SendChatMessage(text, kind, language, target, priority, queue, ca
 		kind = "SAY"
 	else
 		kind = kind:upper()
-	end
-
-	if target and kind == "WHISPER" then
-		target = Ambiguate(target, "none")
 	end
 
 	ChatThrottleLib:SendChatMessage(PRIORITY_TO_CTL[priority] or DEFAULT_PRIORITY, "Chomp", text, kind, language, target, queue, callback, callbackArg)


### PR DESCRIPTION
During the investigation into the mysterious™️ comms issue affecting specific pairs of characters, it's been suspected to be caused by the game failing to resolve the proper target of WHISPER comms if the realm name is not specified. While it used to resolve to the character of that name on the same realm as yours, it doesn't appear to be the case anymore as of last year or so.

Realm names don't seem to trip SendAddonMessage if the realm is the same as yours anymore, so we'll stop Ambiguating targets in the hope that it solves once and for all the mysterious™️ bug.