### PR TITLE
Don't check for CODECV2 version bits on receipt

### DIFF
--- a/Internal.lua
+++ b/Internal.lua
@@ -128,14 +128,6 @@ local function HandleMessageIn(prefix, text, channel, sender, target, zoneChanne
 		return
 	end
 
-	local hasVersion16 = bit.band(bitField, Internal.BITS.VERSION16) ~= 0
-	local hasCodecV2 = bit.band(bitField, Internal.BITS.CODECV2) ~= 0
-	if not hasVersion16 or not hasCodecV2 then
-		-- Sender is using a version of Chomp that's far too old. Ignore
-		-- as we probably can't communicate with them anyway.
-		return
-	end
-
 	if not prefixData[sender] then
 		prefixData[sender] = {}
 	end

--- a/Internal.lua
+++ b/Internal.lua
@@ -14,7 +14,7 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-local VERSION = 31
+local VERSION = 32
 
 if IsLoggedIn() then
 	error(("Chomp Message Library (embedded: %s) cannot be loaded after login."):format((...)))

--- a/Public.lua
+++ b/Public.lua
@@ -282,9 +282,9 @@ function Chomp.SmartAddonMessage(prefix, data, kind, target, messageOptions)
 
 	local bitField = 0x000
 
-	-- v20+: Always set the CODECV2 bit. All clients on the network at this
-	--       point should support it. Setting this bit unconditionally will
-	--       eventually allow us to deprecate receipt of v1 codec data.
+	-- v32+: Always set the VERSION16 and CODECV2 bits. Versions older than
+	--       this will discard messages without these bits set. Once newer
+	--       versions are widely distributed, we can stop setting these bits.
 	bitField = bit.bor(bitField, Internal.BITS.VERSION16, Internal.BITS.CODECV2)
 
 	if messageOptions.serialize then

--- a/Public.lua
+++ b/Public.lua
@@ -282,9 +282,9 @@ function Chomp.SmartAddonMessage(prefix, data, kind, target, messageOptions)
 
 	local bitField = 0x000
 
-	-- v32+: Always set the VERSION16 and CODECV2 bits. Versions older than
-	--       this will discard messages without these bits set. Once newer
-	--       versions are widely distributed, we can stop setting these bits.
+	-- v32: Always set the VERSION16 and CODECV2 bits. Versions older than
+	--      this will discard messages without these bits set. Once newer
+	--      versions are widely distributed, we can stop setting these bits.
 	bitField = bit.bor(bitField, Internal.BITS.VERSION16, Internal.BITS.CODECV2)
 
 	if messageOptions.serialize then


### PR DESCRIPTION
These bits have been unilaterally set on all messages since Chomp v20+.

It'd be nice to reclaim these bits for the message header, so we should stop checking that they're set and assume we live in a modern world. Longer term (~12.0) we can stop setting them entirely, and a bit after that we can rename the bits and mark them unused again.