### PR TITLE
Centralize realm name normalization

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -49,7 +49,6 @@ read_globals = {
 	"ChatFrame_AddMessageEventFilter",
 	"CreateFrame",
 	"ERR_CHAT_PLAYER_NOT_FOUND_S",
-	"FULL_PLAYER_NAME",
 	"GetAutoCompleteRealms",
 	"GetNetStats",
 	"GetRealmName",

--- a/Internal.lua
+++ b/Internal.lua
@@ -354,10 +354,6 @@ local function EnumerateFriendGameAccounts()
 	return NextGameAccount
 end
 
-local function NormalizeRealmName(realmName)
-	return (string.gsub(realmName, "[%s-]", ""))
-end
-
 local function CanExchangeWithGameAccount(account)
 	if not account.isOnline then
 		return false  -- Friend isn't even online.
@@ -368,7 +364,7 @@ local function CanExchangeWithGameAccount(account)
 	end
 
 	local characterName = account.characterName
-	local realmName     = account.realmName and NormalizeRealmName(account.realmName) or nil
+	local realmName     = account.realmName and Chomp.NormalizeRealmName(account.realmName) or nil
 	local factionName   = account.factionName
 
 	if not characterName or characterName == "" or characterName == UNKNOWNOBJECT then
@@ -394,7 +390,7 @@ function Internal:UpdateBattleNetAccountData()
 	for _, _, account in EnumerateFriendGameAccounts() do
 		if CanExchangeWithGameAccount(account) then
 			local characterName = account.characterName
-			local realmName = string.gsub(account.realmName, "[%s*%-*]", "")
+			local realmName = Chomp.NormalizeRealmName(account.realmName)
 			local mergedName = Chomp.NameMergedRealm(characterName, realmName)
 
 			self.bnetGameAccounts[mergedName] = account.gameAccountID
@@ -475,9 +471,9 @@ Internal:SetScript("OnEvent", function(self, event, ...)
 		hooksecurefunc(C_ChatInfo, "SendAddonMessageLogged", HookSendAddonMessageLogged)
 		ChatFrame_AddMessageEventFilter("CHAT_MSG_SYSTEM", MessageEventFilter_SYSTEM)
 		self.SameRealm = {}
-		self.SameRealm[(GetRealmName():gsub("[%s%-]", ""))] = true
+		self.SameRealm[(Chomp.NormalizeRealmName(GetRealmName()))] = true
 		for i, realm in ipairs(GetAutoCompleteRealms()) do
-			self.SameRealm[(realm:gsub("[%s%-]", ""))] = true
+			self.SameRealm[(Chomp.NormalizeRealmName(realm))] = true
 		end
 		Internal.isReady = true
 		if self.IncomingQueue then

--- a/Internal.lua
+++ b/Internal.lua
@@ -14,7 +14,7 @@
 	CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 
-local VERSION = 31
+local VERSION = 32
 
 if IsLoggedIn() then
 	error(("Chomp Message Library (embedded: %s) cannot be loaded after login."):format((...)))


### PR DESCRIPTION
There's a few (incorrect) patterns being used for realm name normalization. Fix these up and relocate to a single function to
handle this.

Additionally, clean up some logic that involved de-formatting a global string (FULL_PLAYER_NAME) to instead use split/join calls.