### PR TITLE
Sanitize square braces from loadstring inputs

### DIFF
--- a/StringManip.lua
+++ b/StringManip.lua
@@ -199,7 +199,7 @@ local function IsStringLoadSafe(str)
 	local inQuotedString = false
 
 	repeat
-		offset = strfind(str, [=[["\(]]=], offset)
+		offset = strfind(str, [=[["\(%[%]]]=], offset)
 
 		if not offset then
 			break

--- a/StringManip.lua
+++ b/StringManip.lua
@@ -199,7 +199,7 @@ local function IsStringLoadSafe(str)
 	local inQuotedString = false
 
 	repeat
-		offset = strfind(str, [=[["\(%[%]]]=], offset)
+		offset = strfind(str, [=[["\(%[]]=], offset)
 
 		if not offset then
 			break
@@ -217,8 +217,10 @@ local function IsStringLoadSafe(str)
 				offset = offset + 1
 			end
 		elseif not inQuotedString then
-			-- Found either a backslash or left-paren outside a string.
-			return false, string.format("unexpected character \"%1$s\" at offset %2$d", string.char(byte), offset)
+			if byte ~= 0x5b or strfind(str, "^%[[=%[]", offset) then
+				-- Found either a backslash or left-paren outside a string, or the start of an '[[' style string.
+				return false, string.format("unexpected character \"%1$s\" at offset %2$d", string.char(byte), offset)
+			end
 		end
 
 		offset = offset + 1

--- a/StringManip.lua
+++ b/StringManip.lua
@@ -199,7 +199,7 @@ local function IsStringLoadSafe(str)
 	local inQuotedString = false
 
 	repeat
-		offset = strfind(str, [=[["\(%[]]=], offset)
+		offset = strfind(str, '["\\([\n-]', offset)
 
 		if not offset then
 			break
@@ -217,9 +217,12 @@ local function IsStringLoadSafe(str)
 				offset = offset + 1
 			end
 		elseif not inQuotedString then
-			if byte ~= 0x5b or strfind(str, "^%[[=%[]", offset) then
-				-- Found either a backslash or left-paren outside a string, or the start of an '[[' style string.
-				return false, string.format("unexpected character \"%1$s\" at offset %2$d", string.char(byte), offset)
+			if byte == 0x5b and strfind(str, '^[[=]', offset + 1) then
+			    return false, string.format("unexpected long string at offset %1$d", offset)
+			elseif byte == 0x2d and strfind(str, '^%-', offset + 1) then
+			    return false, string.format("unexpected comment at offset %1$d", offset)
+			elseif byte ~= 0x5b and byte ~= 0x2d then
+			    return false, string.format("unexpected character \"%1$s\" at offset %2$d", string.char(byte), offset)
 			end
 		end
 


### PR DESCRIPTION
It's possible to bypass our loadstring sanitization if fed an input of `[["]] .. (function() ... end)()`.

We now sanitize any occurrences of `[[` or `[=` occurring outside of a quoted string, triggering an "unexpected character" message on such inputs. This doesn't impact the few cases of table keys being serialized as `["break"] = true` since we shouldn't be generating back-to-back `[[` in our serializer anyway (we only use it for table keys, which are guaranteed to be delimited either by `{` or `,`.)